### PR TITLE
fix: missing ws types

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -12,6 +12,7 @@
     "@runtyping/zod": "2.1.1",
     "@trpc/client": "11.0.0-rc.553",
     "@trpc/server": "11.0.0-rc.553",
+    "@types/ws": "8.5.12",
     "@xterm/addon-attach": "0.11.0",
     "@xterm/addon-fit": "0.10.0",
     "@xterm/xterm": "5.5.0",
@@ -25,7 +26,6 @@
   },
   "devDependencies": {
     "@types/node": "22.7.4",
-    "@types/ws": "8.5.12",
     "concurrently": "9.0.1",
     "nodemon": "3.1.7",
     "prettier-plugin-organize-imports": "4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@trpc/server':
         specifier: 11.0.0-rc.553
         version: 11.0.0-rc.553
+      '@types/ws':
+        specifier: 8.5.12
+        version: 8.5.12
       '@xterm/addon-attach':
         specifier: 0.11.0
         version: 0.11.0(@xterm/xterm@5.5.0)
@@ -141,9 +144,6 @@ importers:
       '@types/node':
         specifier: 22.7.4
         version: 22.7.4
-      '@types/ws':
-        specifier: 8.5.12
-        version: 8.5.12
       concurrently:
         specifier: 9.0.1
         version: 9.0.1


### PR DESCRIPTION
This caused the following error:

    ../node_modules/.pnpm/@tui-sandbox+library@2.0.0_typescript@5.6.2/node_modules/@tui-sandbox/library/src/server/connection/trpc.ts:4:32 - error TS7016: Could not find a declaration file for module 'ws'. '/Users/mikavilpas/git/yazi.nvim/node_modules/.pnpm/ws@8.18.0/node_modules/ws/wrapper.mjs' implicitly has an 'any' type.
      Try `npm i --save-dev @types/ws` if it exists or add a new declaration (.d.ts) file containing `declare module 'ws';`

    4 import type { WebSocket } from "ws"
                                    ~~~~