### PR TITLE
fix: zoomed in screen sizes could lose text

### DIFF
--- a/packages/library/src/client/neovim-client.ts
+++ b/packages/library/src/client/neovim-client.ts
@@ -60,12 +60,14 @@ export class NeovimClient {
     await this.ready
 
     const neovim = await this.trpc.neovim.start.mutate({
-      startNeovimArguments: args,
-      tabId: this.tabId,
-      terminalDimensions: {
-        cols: this.terminal.cols,
-        rows: this.terminal.rows,
+      startNeovimArguments: {
+        ...args,
+        terminalDimensions: {
+          cols: this.terminal.cols,
+          rows: this.terminal.rows,
+        },
       },
+      tabId: this.tabId,
     })
 
     return neovim

--- a/packages/library/src/server/neovim/NeovimApplication.ts
+++ b/packages/library/src/server/neovim/NeovimApplication.ts
@@ -54,7 +54,7 @@ Run "nvim -V1 -v" for more info
 export type StdoutMessage = "stdout"
 
 export type StartNeovimGenericArguments = {
-  terminalDimensions?: { cols: number; rows: number }
+  terminalDimensions: { cols: number; rows: number }
   filename: string | { openInVerticalSplits: string[] }
   startupScriptModifications?: string[]
 }

--- a/packages/library/src/server/server.ts
+++ b/packages/library/src/server/server.ts
@@ -21,12 +21,6 @@ function createAppRouter(config: TestServerConfig) {
         .input(
           z.object({
             tabId: tabIdSchema,
-            terminalDimensions: z
-              .object({
-                cols: z.number(),
-                rows: z.number(),
-              })
-              .optional(),
             startNeovimArguments: z.object({
               filename: z.union([
                 z.string(),
@@ -35,6 +29,10 @@ function createAppRouter(config: TestServerConfig) {
                 }),
               ]),
               startupScriptModifications: z.array(z.string()).optional(),
+              terminalDimensions: z.object({
+                cols: z.number(),
+                rows: z.number(),
+              }),
             }),
           })
         )

--- a/packages/library/src/server/utilities/TerminalApplication.ts
+++ b/packages/library/src/server/utilities/TerminalApplication.ts
@@ -5,10 +5,6 @@ import type { ITerminalDimensions } from "@xterm/addon-fit"
 import type { IPty } from "node-pty"
 import pty from "node-pty"
 
-// NOTE the size for the terminal was chosen so that it looks good in my
-// cypress test preview
-const defaultDimensions: ITerminalDimensions = { cols: 125, rows: 43 }
-
 // NOTE separating stdout and stderr is not supported by node-pty
 // https://github.com/microsoft/node-pty/issues/71
 export class TerminalApplication {
@@ -46,17 +42,15 @@ export class TerminalApplication {
     args,
     cwd,
     env,
-    dimensions: givenDimensions,
+    dimensions,
   }: {
     onStdoutOrStderr: (data: string) => void
     command: string
     args: string[]
     cwd: string
     env?: NodeJS.ProcessEnv
-    dimensions?: ITerminalDimensions
+    dimensions: ITerminalDimensions
   }): TerminalApplication {
-    const dimensions = givenDimensions ?? defaultDimensions
-
     console.log(`Starting '${command} ${args.join(" ")}' in cwd '${cwd}'`)
     const ptyProcess = pty.spawn(command, args, {
       name: "xterm-color",


### PR DESCRIPTION
Issue
=====

When cypress was used in a browser that was zoomed in, or otherwise used a screen size that conflicted with the xterm.js size calculation logic, the terminal would be too small and some text could be lost.

This was caused by ignoring the client's terminal size when starting a new TerminalApplication instance, and using a hardcoded default size instead.

Solution
========

Use the client's terminal size when starting a new TerminalApplication so that no text is lost.