### PR TITLE
refactor: adapt to trpc v11 async generator subscription

### DIFF
--- a/packages/library/src/server/neovim/NeovimApplication.ts
+++ b/packages/library/src/server/neovim/NeovimApplication.ts
@@ -113,7 +113,8 @@ export class NeovimApplication extends DisposableSingleApplication {
       env: process.env,
       dimensions: startArgs.terminalDimensions,
 
-      onStdoutOrStderr(data: string) {
+      onStdoutOrStderr(data) {
+        data satisfies string
         stdout.emit("stdout" satisfies StdoutMessage, data)
       },
     })

--- a/packages/library/src/server/neovim/index.ts
+++ b/packages/library/src/server/neovim/index.ts
@@ -12,7 +12,7 @@ const neovims = new Map<TabId["tabId"], NeovimApplication>()
 async function* eventEmitterToAsyncGenerator(
   emitter: EventEmitter,
   eventName: string
-): AsyncGenerator<unknown, void, unknown> {
+): AsyncGenerator<string, void, unknown> {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   while (true) {
     yield await new Promise(resolve => {
@@ -25,7 +25,7 @@ export async function onStdout(
   options: { client: TabId },
   signal: AbortSignal | undefined,
   testEnvironmentPath: string
-): Promise<AsyncGenerator<unknown, void, unknown>> {
+): Promise<AsyncGenerator<string, void, unknown>> {
   const tabId = options.client.tabId
   const neovim = neovims.get(tabId) ?? new NeovimApplication(testEnvironmentPath)
   if (neovims.get(tabId) === undefined) {

--- a/packages/library/src/server/neovim/index.ts
+++ b/packages/library/src/server/neovim/index.ts
@@ -1,37 +1,47 @@
-import type { Observable } from "@trpc/server/observable"
-import { observable } from "@trpc/server/observable"
 import assert from "assert"
+import type EventEmitter from "events"
 import type { TestDirectory } from "../types"
 import type { TestServerConfig } from "../updateTestdirectorySchemaFile"
 import type { TabId } from "../utilities/tabId"
 import { createTempDir } from "./environment/createTempDir"
-import type { StartNeovimGenericArguments, StdoutMessage } from "./NeovimApplication"
+import type { StartNeovimGenericArguments } from "./NeovimApplication"
 import { NeovimApplication } from "./NeovimApplication"
 
 const neovims = new Map<TabId["tabId"], NeovimApplication>()
 
-export function onStdout(options: { client: TabId }, testEnvironmentPath: string): Observable<string, unknown> {
-  return observable<string>(emit => {
-    const tabId = options.client.tabId
-    const neovim = neovims.get(tabId) ?? new NeovimApplication(testEnvironmentPath)
-    if (neovims.get(tabId) === undefined) {
-      neovims.set(tabId, neovim)
-    }
+async function* eventEmitterToAsyncGenerator(
+  emitter: EventEmitter,
+  eventName: string
+): AsyncGenerator<unknown, void, unknown> {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  while (true) {
+    yield await new Promise(resolve => {
+      emitter.once(eventName, resolve)
+    })
+  }
+}
 
-    const send = (data: unknown) => {
-      assert(typeof data === "string")
-      emit.next(data)
-    }
+export async function onStdout(
+  options: { client: TabId },
+  signal: AbortSignal | undefined,
+  testEnvironmentPath: string
+): Promise<AsyncGenerator<unknown, void, unknown>> {
+  const tabId = options.client.tabId
+  const neovim = neovims.get(tabId) ?? new NeovimApplication(testEnvironmentPath)
+  if (neovims.get(tabId) === undefined) {
+    neovims.set(tabId, neovim)
+  }
 
-    neovim.events.on("stdout" satisfies StdoutMessage, send)
-
-    return () => {
-      neovim.events.off("stdout" satisfies StdoutMessage, send)
+  const stdout = eventEmitterToAsyncGenerator(neovim.events, "stdout")
+  if (signal) {
+    signal.addEventListener("abort", () => {
       void neovim[Symbol.asyncDispose]().finally(() => {
         neovims.delete(tabId)
       })
-    }
-  })
+    })
+  }
+
+  return stdout
 }
 
 export async function start(

--- a/packages/library/src/server/server.ts
+++ b/packages/library/src/server/server.ts
@@ -40,7 +40,7 @@ function createAppRouter(config: TestServerConfig) {
           return neovim.start(options.input.startNeovimArguments, options.input.tabId, config)
         }),
       onStdout: trpc.procedure.input(z.object({ client: tabIdSchema })).subscription(options => {
-        return neovim.onStdout(options.input, config.testEnvironmentPath)
+        return neovim.onStdout(options.input, options.signal, config.testEnvironmentPath)
       }),
       sendStdin: trpc.procedure.input(z.object({ tabId: tabIdSchema, data: z.string() })).mutation(options => {
         return neovim.sendStdin(options.input)


### PR DESCRIPTION
- https://trpc.io/docs/migrate-from-v10-to-v11#deprecation-of-subscriptions-returning-observables-non-breaking
- https://trpc.io/docs/migrate-from-v10-to-v11#subscription-procedure-output-type-changed-to-asyncgenerator-non-breaking