### PR TITLE
feat: client connects to server using server-sent events

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -11,21 +11,21 @@
     "@catppuccin/palette": "1.5.0",
     "@trpc/client": "11.0.0-rc.608",
     "@trpc/server": "11.0.0-rc.608",
-    "@types/ws": "8.5.12",
     "@xterm/addon-attach": "0.11.0",
     "@xterm/addon-fit": "0.10.0",
     "@xterm/xterm": "5.5.0",
     "core-js": "3.39.0",
+    "cors": "2.8.5",
     "dree": "5.1.5",
     "node-pty": "1.0.0",
     "prettier": "3.3.3",
     "type-fest": "4.26.1",
     "winston": "3.16.0",
-    "ws": "8.18.0",
     "zod": "3.23.8"
   },
   "devDependencies": {
     "@runtyping/zod": "2.1.1",
+    "@types/cors": "2.8.17",
     "@types/node": "22.8.6",
     "nodemon": "3.1.7",
     "vitest": "2.1.4"

--- a/packages/library/src/server/TestServer.ts
+++ b/packages/library/src/server/TestServer.ts
@@ -1,53 +1,45 @@
 import type { AnyTRPCRouter } from "@trpc/server"
-import { applyWSSHandler } from "@trpc/server/adapters/ws"
+import { createHTTPServer } from "@trpc/server/adapters/standalone"
 import "core-js/proposals/async-explicit-resource-management"
+import cors from "cors"
 import { once } from "events"
-import { WebSocketServer } from "ws"
-import { createContext } from "./connection/trpc"
 import type { TestServerConfig } from "./updateTestdirectorySchemaFile"
 import { updateTestdirectorySchemaFile } from "./updateTestdirectorySchemaFile"
 
 export class TestServer {
   public constructor(private readonly port: number) {}
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
-  public async startAndRun<TRouter extends AnyTRPCRouter>(appRouter: TRouter, config: TestServerConfig): Promise<void> {
+  public async startAndRun(appRouter: AnyTRPCRouter, config: TestServerConfig): Promise<void> {
     console.log("🚀 Server starting")
 
     await updateTestdirectorySchemaFile(config)
 
-    const wss = new WebSocketServer({ port: this.port })
-    const handler = applyWSSHandler<TRouter>({
-      wss,
+    const server = createHTTPServer({
       router: appRouter,
-      createContext,
-      // Enable heartbeat messages to keep connection open (disabled by default)
-      keepAlive: {
-        enabled: true,
-        // server ping message interval in milliseconds
-        pingMs: 30_000,
-        // connection is terminated if pong message is not received in this many milliseconds
-        pongWaitMs: 5000,
-      },
+      createContext: () => ({}),
+      middleware: cors({
+        origin: "*",
+      }),
     })
 
-    wss.on("connection", socket => {
-      console.log(`➕➕ Connection (${wss.clients.size})`)
+    server.listen(this.port)
+    server.on("connection", socket => {
+      console.log(`➕➕ Connection`)
       socket.once("close", () => {
-        console.log(`➖➖ Connection (${wss.clients.size})`)
+        console.log(`➖➖ Connection`)
       })
     })
-    console.log(`✅ WebSocket Server listening on ws://localhost:${this.port}`)
+
+    console.log(`✅ Server listening on ws://localhost:${this.port}`)
 
     await Promise.race([once(process, "SIGTERM"), once(process, "SIGINT")])
     console.log("Shutting down...")
-    handler.broadcastReconnectNotification()
-    wss.close(error => {
+    server.close(error => {
       if (error) {
-        console.error("Error closing WebSocket server", error)
+        console.error("Error closing server", error)
         process.exit(1)
       }
-      console.log("WebSocket server closed")
+      console.log("Server closed")
       process.exit(0)
     })
   }

--- a/packages/library/src/server/connection/trpc.ts
+++ b/packages/library/src/server/connection/trpc.ts
@@ -1,17 +1,3 @@
 import { initTRPC } from "@trpc/server"
-import type { CreateWSSContextFnOptions } from "@trpc/server/adapters/ws"
-import type { Socket } from "net"
-import type { WebSocket } from "ws"
 
-export type Connection = {
-  clientId: WebSocket
-  socket: Socket
-}
-
-export function createContext(opts: CreateWSSContextFnOptions): Connection {
-  return { clientId: opts.res, socket: opts.req.socket }
-}
-
-type Context = Awaited<ReturnType<typeof createContext>>
-
-export const trpc = initTRPC.context<Context>().create()
+export const trpc = initTRPC.context<object>().create()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,9 +98,6 @@ importers:
       '@trpc/server':
         specifier: 11.0.0-rc.608
         version: 11.0.0-rc.608
-      '@types/ws':
-        specifier: 8.5.12
-        version: 8.5.12
       '@xterm/addon-attach':
         specifier: 0.11.0
         version: 0.11.0(@xterm/xterm@5.5.0)
@@ -113,6 +110,9 @@ importers:
       core-js:
         specifier: 3.39.0
         version: 3.39.0
+      cors:
+        specifier: 2.8.5
+        version: 2.8.5
       dree:
         specifier: 5.1.5
         version: 5.1.5
@@ -128,9 +128,6 @@ importers:
       winston:
         specifier: 3.16.0
         version: 3.16.0
-      ws:
-        specifier: 8.18.0
-        version: 8.18.0
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -138,6 +135,9 @@ importers:
       '@runtyping/zod':
         specifier: 2.1.1
         version: 2.1.1(typescript@5.6.3)(zod@3.23.8)
+      '@types/cors':
+        specifier: 2.8.17
+        version: 2.8.17
       '@types/node':
         specifier: 22.8.6
         version: 22.8.6
@@ -691,6 +691,9 @@ packages:
   '@ts-morph/common@0.21.0':
     resolution: {integrity: sha512-ES110Mmne5Vi4ypUKrtVQfXFDtCsDXiUiGxF6ILVlE90dDD4fdpC1LSjydl/ml7xJWKSDZwUYD2zkOePMSrPBA==}
 
+  '@types/cors@2.8.17':
+    resolution: {integrity: sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -735,9 +738,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/ws@8.5.12':
-    resolution: {integrity: sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -1171,6 +1171,10 @@ packages:
 
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig@9.0.0:
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
@@ -3007,6 +3011,10 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
 
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
   verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
@@ -3594,6 +3602,10 @@ snapshots:
       mkdirp: 2.1.6
       path-browserify: 1.0.1
 
+  '@types/cors@2.8.17':
+    dependencies:
+      '@types/node': 22.8.6
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 0.7.34
@@ -3632,10 +3644,6 @@ snapshots:
   '@types/triple-beam@1.3.5': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/ws@8.5.12':
-    dependencies:
-      '@types/node': 22.8.6
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -4128,6 +4136,11 @@ snapshots:
   core-js@3.39.0: {}
 
   core-util-is@1.0.2: {}
+
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cosmiconfig@9.0.0(typescript@5.6.3):
     dependencies:
@@ -6350,6 +6363,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@8.3.2: {}
+
+  vary@1.1.2: {}
 
   verror@1.10.0:
     dependencies:


### PR DESCRIPTION
tRPC deprecated the WebSocket client and server adapters in favor of server-sent events (SSE) and HTTP. This project does not need a two-way WebSocket connection (we only read the output from neovim using the stream), so might as well upgrade to server-sent events.

Reused the example implementation from this issue reproduction (thanks!) https://github.com/trpc/trpc/issues/6045