### PR TITLE
ci: only test with nightly neovim

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        neovim_version: ["nightly", "stable"]
+        neovim_version: ["nightly"]
 
     steps:
       - uses: actions/checkout@v4.2.2


### PR DESCRIPTION
The tests do not need many features from neovim at all. Simplify the build by only testing with the nightly version of neovim.