### PR TITLE
feat(wip): allow access to neovim via a type safe socket connection

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -18,6 +18,7 @@
     "core-js": "3.39.0",
     "cors": "2.8.5",
     "dree": "5.1.5",
+    "neovim": "5.3.0",
     "node-pty": "1.0.0",
     "prettier": "3.3.3",
     "type-fest": "4.26.1",

--- a/packages/library/src/server/neovim/NeovimJavascriptApiClient.test.ts
+++ b/packages/library/src/server/neovim/NeovimJavascriptApiClient.test.ts
@@ -1,0 +1,42 @@
+import { access } from "fs/promises"
+import { attach } from "neovim"
+import type { PollingInterval } from "./NeovimJavascriptApiClient"
+import { connectNeovimApi } from "./NeovimJavascriptApiClient"
+
+vi.mock("neovim")
+vi.mock("fs/promises")
+
+const mocked = {
+  attach: vi.mocked(attach),
+  access: vi.mocked(access),
+  log: vi.spyOn(console, "log").mockImplementation(() => {
+    //
+  }),
+}
+const pollingInterval = 100 satisfies PollingInterval
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+it("is lazy - does not connect right away", async () => {
+  mocked.access.mockRejectedValue(new Error("no such file or directory"))
+  connectNeovimApi("foosocket")
+
+  vi.advanceTimersByTime(pollingInterval)
+  expect(mocked.attach).not.toHaveBeenCalled()
+})
+
+it("connects right away if the socket file is already there", async () => {
+  mocked.access.mockResolvedValue(undefined)
+  const lazyClient = connectNeovimApi("foosocket")
+  await lazyClient.get()
+
+  vi.advanceTimersByTime(pollingInterval)
+  expect(mocked.attach).toHaveBeenCalledWith({ socket: "foosocket" })
+  expect(mocked.attach).toHaveBeenCalledTimes(1)
+})

--- a/packages/library/src/server/neovim/NeovimJavascriptApiClient.ts
+++ b/packages/library/src/server/neovim/NeovimJavascriptApiClient.ts
@@ -1,0 +1,27 @@
+import { access } from "fs/promises"
+import type { NeovimClient as NeovimApiClient } from "neovim"
+import { attach } from "neovim"
+import { Lazy } from "../utilities/Lazy"
+
+export type NeovimJavascriptApiClient = NeovimApiClient
+
+export type PollingInterval = 100
+
+export function connectNeovimApi(socketPath: string): Lazy<Promise<NeovimJavascriptApiClient>> {
+  // it takes about 100ms for the socket file to be created - best make this
+  // Lazy so that we don't wait for it unnecessarily.
+  return new Lazy(async () => {
+    for (let i = 0; i < 100; i++) {
+      try {
+        await access(socketPath)
+        console.log(`socket file ${socketPath} created after at attempt ${i + 1}`)
+        break
+      } catch (e) {
+        console.log(`polling for socket file ${socketPath} to be created (attempt ${i + 1})`)
+        await new Promise(resolve => setTimeout(resolve, 100 satisfies PollingInterval))
+      }
+    }
+
+    return attach({ socket: socketPath })
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       dree:
         specifier: 5.1.5
         version: 5.1.5
+      neovim:
+        specifier: 5.3.0
+        version: 5.3.0
       node-pty:
         specifier: 1.0.0
         version: 1.0.0
@@ -541,6 +544,10 @@ packages:
 
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
+
+  '@msgpack/msgpack@2.8.0':
+    resolution: {integrity: sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==}
+    engines: {node: '>= 10'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2309,6 +2316,11 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
+  neovim@5.3.0:
+    resolution: {integrity: sha512-32Cypq6qh7vzJ5wuVPPzIsBdOlvwo0do8/3jxLu+RGdneFSJjh5CYi0ScHHAw/2HLtIjRKhRjJMXeze21M+uyw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
@@ -3122,6 +3134,10 @@ packages:
     resolution: {integrity: sha512-wQCXXVgfv/wUPOfb2x0ruxzwkcZfxcktz6JIMUaPLmcNhO4bZTwA/WtDWK74xV3F2dKu8YadrFv0qhwYjVEwhA==}
     engines: {node: '>= 12.0.0'}
 
+  winston@3.14.1:
+    resolution: {integrity: sha512-CJi4Il/msz8HkdDfXOMu+r5Au/oyEjFiOZzbX2d23hRLY0narGjqfE5lFlrT5hfYJhPtM8b85/GNFsxIML/RVA==}
+    engines: {node: '>= 12.0.0'}
+
   winston@3.16.0:
     resolution: {integrity: sha512-xz7+cyGN5M+4CmmD4Npq1/4T+UZaz7HaeTlAruFUTjk79CNMq+P6H30vlE4z0qfqJ01VHYQwd7OZo03nYm/+lg==}
     engines: {node: '>= 12.0.0'}
@@ -3467,6 +3483,8 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jsdevtools/ono@7.1.3': {}
+
+  '@msgpack/msgpack@2.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5608,6 +5626,11 @@ snapshots:
   negotiator@0.6.3:
     optional: true
 
+  neovim@5.3.0:
+    dependencies:
+      '@msgpack/msgpack': 2.8.0
+      winston: 3.14.1
+
   netmask@2.0.2: {}
 
   next-tick@1.1.0: {}
@@ -6488,6 +6511,20 @@ snapshots:
       logform: 2.6.1
       readable-stream: 3.6.2
       triple-beam: 1.4.1
+
+  winston@3.14.1:
+    dependencies:
+      '@colors/colors': 1.6.0
+      '@dabh/diagnostics': 2.0.3
+      async: 3.2.6
+      is-stream: 2.0.1
+      logform: 2.6.1
+      one-time: 1.0.0
+      readable-stream: 3.6.2
+      safe-stable-stringify: 2.5.0
+      stack-trace: 0.0.10
+      triple-beam: 1.4.1
+      winston-transport: 4.7.1
 
   winston@3.16.0:
     dependencies:


### PR DESCRIPTION
This change is a bit of work-in-progress effort. It does not actually expose the client yet. I'll have to think how it could be done, since we have to run the tests in the browser, but the client exists on the backend.

Right now I want to roll this out to see if causes any stability issues. It's lazy so it should basically do nothing right now.