### PR TITLE
feat!: Neovim supports the .config directory for user configuration

### DIFF
--- a/packages/integration-tests/MyTestDirectory.ts
+++ b/packages/integration-tests/MyTestDirectory.ts
@@ -14,6 +14,30 @@ export const MyTestDirectorySchema = z.object({
   name: z.literal("test-environment/"),
   type: z.literal("directory"),
   contents: z.object({
+    ".config": z.object({
+      name: z.literal(".config/"),
+      type: z.literal("directory"),
+      contents: z.object({
+        ".gitkeep": z.object({
+          name: z.literal(".gitkeep"),
+          type: z.literal("file"),
+          extension: z.literal(""),
+          stem: z.literal(".gitkeep"),
+        }),
+        nvim: z.object({
+          name: z.literal("nvim/"),
+          type: z.literal("directory"),
+          contents: z.object({
+            "init.lua": z.object({
+              name: z.literal("init.lua"),
+              type: z.literal("file"),
+              extension: z.literal("lua"),
+              stem: z.literal("init."),
+            }),
+          }),
+        }),
+      }),
+    }),
     "config-modifications": z.object({
       name: z.literal("config-modifications/"),
       type: z.literal("directory"),
@@ -110,12 +134,6 @@ export const MyTestDirectorySchema = z.object({
         }),
       }),
     }),
-    "test-setup.lua": z.object({
-      name: z.literal("test-setup.lua"),
-      type: z.literal("file"),
-      extension: z.literal("lua"),
-      stem: z.literal("test-setup."),
-    }),
   }),
 })
 
@@ -125,6 +143,10 @@ export type MyTestDirectoryContentsSchemaType = z.infer<typeof MyTestDirectorySc
 export type MyTestDirectory = MyTestDirectoryContentsSchemaType["contents"]
 
 export const testDirectoryFiles = z.enum([
+  ".config/.gitkeep",
+  ".config/nvim/init.lua",
+  ".config/nvim",
+  ".config",
   "config-modifications/add_command_to_count_open_buffers.lua",
   "config-modifications",
   "dir with spaces/file1.txt",
@@ -141,7 +163,6 @@ export const testDirectoryFiles = z.enum([
   "routes",
   "subdirectory/subdirectory-file.txt",
   "subdirectory",
-  "test-setup.lua",
   ".",
 ])
 export type MyTestDirectoryFile = z.infer<typeof testDirectoryFiles>

--- a/packages/integration-tests/cypress/e2e/neovim.cy.ts
+++ b/packages/integration-tests/cypress/e2e/neovim.cy.ts
@@ -3,6 +3,17 @@ import { rgbify } from "../../../library/src/client/color-utilities"
 import type { MyTestDirectoryFile } from "../../MyTestDirectory"
 
 describe("neovim features", () => {
+  it("can load a custom init.lua file from the .config/nvim directory", () => {
+    cy.visit("/")
+    cy.startNeovim().then(() => {
+      // wait until text on the start screen is visible
+      cy.contains("If you see this text, Neovim is ready!")
+
+      cy.typeIntoTerminal(":=_G.isInitFileLoaded{enter}")
+      cy.contains("yesTheInitFileIsLoaded")
+    })
+  })
+
   it("can start with startupScriptModifications and open another file", () => {
     cy.visit("/")
     cy.startNeovim({

--- a/packages/integration-tests/test-environment/.config/nvim/init.lua
+++ b/packages/integration-tests/test-environment/.config/nvim/init.lua
@@ -1,34 +1,25 @@
 -- This files defines how to initialize the test environment for the
 -- integration tests. It should be executed before running the tests.
 
----@module "lazy"
----@module "catppuccin"
-
--- DO NOT change the paths and don't remove the colorscheme
-local root = vim.fn.fnamemodify("./.repro", ":p")
-vim.env.LAZY_STDPATH = ".repro"
-
--- set stdpaths to use .repro
-for _, name in ipairs({ "config", "data", "state", "cache" }) do
-	vim.env[("XDG_%s_HOME"):format(name:upper())] = root .. "/" .. name
-end
+-- this is used in some tests
+_G.isInitFileLoaded = "yesTheInitFileIsLoaded"
 
 -- Bootstrap lazy.nvim
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
-if not (vim.uv).fs_stat(lazypath) then
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
 	local lazyrepo = "https://github.com/folke/lazy.nvim.git"
-	vim.fn.system({
-		"git",
-		"clone",
-		"--filter=blob:none",
-		"--branch=v11.14.1",
-		lazyrepo,
-		lazypath,
-	})
+	local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
+	if vim.v.shell_error ~= 0 then
+		vim.api.nvim_echo({
+			{ "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+			{ out, "WarningMsg" },
+			{ "\nPress any key to exit..." },
+		}, true, {})
+		vim.fn.getchar()
+		os.exit(1)
+	end
 end
 vim.opt.rtp:prepend(lazypath)
-
-vim.opt.rtp:prepend("../../")
 
 -- Make sure to setup `mapleader` and `maplocalleader` before
 -- loading lazy.nvim so that mappings are correct.

--- a/packages/library/src/server/dirtree/index.test.ts
+++ b/packages/library/src/server/dirtree/index.test.ts
@@ -39,6 +39,30 @@ describe("dirtree", () => {
         name: z.literal("test-environment/"),
         type: z.literal("directory"),
         contents: z.object({
+          ".config": z.object({
+            name: z.literal(".config/"),
+            type: z.literal("directory"),
+            contents: z.object({
+              ".gitkeep": z.object({
+                name: z.literal(".gitkeep"),
+                type: z.literal("file"),
+                extension: z.literal(""),
+                stem: z.literal(".gitkeep"),
+              }),
+              nvim: z.object({
+                name: z.literal("nvim/"),
+                type: z.literal("directory"),
+                contents: z.object({
+                  "init.lua": z.object({
+                    name: z.literal("init.lua"),
+                    type: z.literal("file"),
+                    extension: z.literal("lua"),
+                    stem: z.literal("init."),
+                  }),
+                }),
+              }),
+            }),
+          }),
           "config-modifications": z.object({
             name: z.literal("config-modifications/"),
             type: z.literal("directory"),
@@ -135,12 +159,6 @@ describe("dirtree", () => {
               }),
             }),
           }),
-          "test-setup.lua": z.object({
-            name: z.literal("test-setup.lua"),
-            type: z.literal("file"),
-            extension: z.literal("lua"),
-            stem: z.literal("test-setup."),
-          }),
         }),
       })
 
@@ -150,6 +168,10 @@ describe("dirtree", () => {
       export type MyDirectoryTree = MyDirectoryTreeContentsSchemaType["contents"]
 
       export const testDirectoryFiles = z.enum([
+        ".config/.gitkeep",
+        ".config/nvim/init.lua",
+        ".config/nvim",
+        ".config",
         "config-modifications/add_command_to_count_open_buffers.lua",
         "config-modifications",
         "dir with spaces/file1.txt",
@@ -166,7 +188,6 @@ describe("dirtree", () => {
         "routes",
         "subdirectory/subdirectory-file.txt",
         "subdirectory",
-        "test-setup.lua",
         "."
       ])
       export type MyTestDirectoryFile = z.infer<typeof testDirectoryFiles>"


### PR DESCRIPTION
This emulates how Neovim users store their configuration in the `~/.config/` directory. Many other applications also store their configuration in this directory, so it makes sense to support it.

BREAKING CHANGE: using the `test-setup.lua` file has been moved to `~/.config/nvim/init.lua` in favor of `init.lua`.