### PR TITLE
feat!: the default cwd for shell commands is the test directory

### DIFF
--- a/packages/integration-tests/cypress/e2e/neovim.cy.ts
+++ b/packages/integration-tests/cypress/e2e/neovim.cy.ts
@@ -99,6 +99,26 @@ describe("neovim features", () => {
       cy.runBlockingShellCommand({ command: "commandnotfoundreallynotfound" }).then(output => {
         assert(output.type === "failed")
       })
+
+      // setting the cwd
+      cy.runBlockingShellCommand({ command: "pwd", cwd: "/" }).then(output => {
+        assert(output.type === "success")
+        expect(output.stdout).to.equal("/\n")
+      })
+
+      // by default, the cwd is the home directory, which is the root of the
+      // unique test environment
+      cy.runBlockingShellCommand({ command: "pwd" }).then(output => {
+        assert(output.type === "success")
+        expect(output.stdout).to.match(/integration-tests\/test-environment\/testdirs\/dir-.*?\n/)
+      })
+
+      // it's possible to use `cd` to change the cwd to a directory defined by
+      // an environment variable
+      cy.runBlockingShellCommand({ command: "cd $XDG_CONFIG_HOME; pwd" }).then(output => {
+        assert(output.type === "success")
+        expect(output.stdout).to.match(/integration-tests\/test-environment\/testdirs\/dir-.*?\/.config\n/)
+      })
     })
   })
 })

--- a/packages/library/src/server/neovim/index.ts
+++ b/packages/library/src/server/neovim/index.ts
@@ -79,13 +79,14 @@ export async function runBlockingShellCommand(
   assert(testDirectory, `Test directory not found for client id ${input.tabId.tabId}. Maybe neovim's not started yet?`)
 
   const execPromise = util.promisify(exec)
+  const env = neovim.getEnvironmentVariables(testDirectory, input.envOverrides)
   const processPromise = execPromise(input.command, {
     signal: signal,
     shell: input.shell,
     uid: input.uid,
     gid: input.gid,
-    cwd: input.cwd,
-    env: neovim.getEnvironmentVariables(testDirectory, input.envOverrides),
+    cwd: input.cwd ?? env["HOME"],
+    env,
   })
 
   try {


### PR DESCRIPTION
BREAKING CHANGE: it used to be the root of the test-environment, but this does not make much sense. Usually we want to operate within the unique test directory only.