### PR TITLE
feat: can run a headless neovim ex-command before tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
           cache: "pnpm"
 
       - run: pnpm install
-      - run: pnpm prettier
       - run: pnpm test
 
       # need to work around https://github.com/cypress-io/github-action/issues/1246

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,18 @@ jobs:
           node-version-file: .nvmrc
           cache: "pnpm"
 
-      - run: pnpm install
-      - run: pnpm test
+      - run: |
+          # install dependencies so we can build the project
+          pnpm install
+          pnpm build
+          # install the "tui" command so it's available for the next steps
+          pnpm install
 
+      - run: pnpm test
       # need to work around https://github.com/cypress-io/github-action/issues/1246
       - run: pnpm --filter integration-tests exec cypress install
+      - name: Preinstall neovim plugins
+        run: pnpm tui neovim exec "Lazy! sync"
 
       - name: Cypress run
         uses: cypress-io/github-action@v6.7.7

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "preinstall": "npx only-allow pnpm",
     "markdownlint": "markdownlint-cli2 README.md",
     "prettier": "prettier --check .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "tui": "pnpm --filter=library build && pnpm --filter integration-tests exec tui"
   },
   "devDependencies": {
     "@eslint/js": "9.16.0",

--- a/packages/library/src/scripts/tui.ts
+++ b/packages/library/src/scripts/tui.ts
@@ -1,32 +1,63 @@
+import assert from "node:assert"
 import { stat } from "node:fs/promises"
 import path from "node:path"
 import { createCypressSupportFile } from "../server/cypress-support/createCypressSupportFile.js"
 import type { TestServerConfig } from "../server/index.js"
 import { startTestServer, updateTestdirectorySchemaFile } from "../server/index.js"
+import type { StdoutOrStderrMessage } from "../server/neovim/NeovimApplication.js"
+import { NeovimApplication } from "../server/neovim/NeovimApplication.js"
+import { prepareNewTestDirectory } from "../server/neovim/index.js"
 
 //
 // This is the main entrypoint to tui-sandbox
 //
 
-// the arguments passed to this script start at index 2
-const args = process.argv.slice(2)
-
-if (args[0] !== "start") {
-  throw new Error(`Usage: tui start`)
-}
 const outputFileName = "MyTestDirectory.ts"
 
 /** The cwd in the user's directory when they are running this script. Not the
  * cwd of the script itself. */
 const cwd = process.cwd()
+const config = {
+  testEnvironmentPath: path.join(cwd, "test-environment/"),
+  outputFilePath: path.join(cwd, outputFileName),
+} satisfies TestServerConfig
+
+// the arguments passed to this script start at index 2
+const args = process.argv.slice(2)
+
+if (args[0] === "neovim") {
+  if (!(args[1] === "exec" && args.length === 3)) {
+    showUsageAndExit()
+  }
+
+  const command = args[2]
+  assert(command, "No command provided")
+
+  {
+    // automatically dispose of the neovim instance when done
+    await using app = new NeovimApplication(config.testEnvironmentPath)
+    app.events.on("stdout" satisfies StdoutOrStderrMessage, data => {
+      console.log(`  neovim output: ${data}`)
+    })
+    const testDirectory = await prepareNewTestDirectory(config)
+    await app.startNextAndKillCurrent(
+      testDirectory,
+      { filename: "empty.txt", headlessCmd: command },
+      { cols: 80, rows: 24 }
+    )
+    await app.application.untilExit()
+  }
+
+  process.exit(0)
+}
+
+if (args[0] !== "start") {
+  showUsageAndExit()
+}
 console.log(`🚀 Starting test server in ${cwd} - this should be the root of your integration-tests directory 🤞🏻`)
 await stat(path.join(cwd, outputFileName))
 
 try {
-  const config = {
-    testEnvironmentPath: path.join(cwd, "test-environment/"),
-    outputFilePath: path.join(cwd, outputFileName),
-  } satisfies TestServerConfig
   await createCypressSupportFile({
     cypressSupportDirectoryPath: path.join(cwd, "cypress", "support"),
     supportFileName: "tui-sandbox.ts",
@@ -35,4 +66,17 @@ try {
   await startTestServer(config)
 } catch (e) {
   console.error(e)
+}
+
+function showUsageAndExit() {
+  console.log(
+    [
+      //
+      `Usage (pick one):`,
+      `    tui start`,
+      `    tui neovim exec '<ex-command>'`,
+    ].join("\n")
+  )
+
+  process.exit(1)
 }

--- a/packages/library/src/server/neovim/NeovimApplication.ts
+++ b/packages/library/src/server/neovim/NeovimApplication.ts
@@ -56,11 +56,14 @@ Run "nvim -V1 -v" for more info
 
 */
 
-export type StdoutMessage = "stdout"
+export type StdoutOrStderrMessage = "stdout"
 
 export type StartNeovimGenericArguments = {
   filename: string | { openInVerticalSplits: string[] }
   startupScriptModifications?: string[]
+
+  /** Executes the given command with --headless -c <command> -c qa */
+  headlessCmd?: string
 
   /** Additions to the environment variables for the Neovim process. These
    * override any already existing environment variables. */
@@ -128,6 +131,13 @@ export class NeovimApplication {
       }
     }
 
+    if (startArgs.headlessCmd) {
+      // NOTE: update the doc comment above if this changes
+      neovimArguments.push("--headless")
+      neovimArguments.push("-c", startArgs.headlessCmd)
+      neovimArguments.push("-c", "qa")
+    }
+
     const id = Math.random().toString().slice(2, 8)
     const socketPath = `${tmpdir()}/tui-sandbox-nvim-socket-${id}`
     neovimArguments.push("--listen", socketPath)
@@ -146,7 +156,7 @@ export class NeovimApplication {
 
         onStdoutOrStderr(data) {
           data satisfies string
-          stdout.emit("stdout" satisfies StdoutMessage, data)
+          stdout.emit("stdout" satisfies StdoutOrStderrMessage, data)
         },
       })
     })

--- a/packages/library/src/server/neovim/NeovimJavascriptApiClient.ts
+++ b/packages/library/src/server/neovim/NeovimJavascriptApiClient.ts
@@ -14,10 +14,10 @@ export function connectNeovimApi(socketPath: string): Lazy<Promise<NeovimJavascr
     for (let i = 0; i < 100; i++) {
       try {
         await access(socketPath)
-        console.log(`socket file ${socketPath} created after at attempt ${i + 1}`)
+        // console.log(`socket file ${socketPath} created after at attempt ${i + 1}`)
         break
       } catch (e) {
-        console.log(`polling for socket file ${socketPath} to be created (attempt ${i + 1})`)
+        // console.log(`polling for socket file ${socketPath} to be created (attempt ${i + 1})`)
         await new Promise(resolve => setTimeout(resolve, 100 satisfies PollingInterval))
       }
     }

--- a/packages/library/src/server/server.ts
+++ b/packages/library/src/server/server.ts
@@ -71,7 +71,7 @@ export async function createAppRouter(config: TestServerConfig) {
           )
         }),
       onStdout: trpc.procedure.input(z.object({ client: tabIdSchema })).subscription(options => {
-        return neovim.onStdout(options.input, options.signal, config.testEnvironmentPath)
+        return neovim.initializeStdout(options.input, options.signal, config.testEnvironmentPath)
       }),
       sendStdin: trpc.procedure.input(z.object({ tabId: tabIdSchema, data: z.string() })).mutation(options => {
         return neovim.sendStdin(options.input)

--- a/packages/library/src/server/utilities/DisposableSingleApplication.ts
+++ b/packages/library/src/server/utilities/DisposableSingleApplication.ts
@@ -1,7 +1,7 @@
 import assert from "assert"
-import type { TerminalApplication } from "./TerminalApplication.js"
+import type { ExitInfo, TerminalApplication } from "./TerminalApplication.js"
 
-export type StartableApplication = Pick<TerminalApplication, "write" | "processId" | "killAndWait">
+export type StartableApplication = Pick<TerminalApplication, "write" | "processId" | "killAndWait" | "untilExit">
 
 /** A testable application that can be started, killed, and given input. For a
  * single instance of this interface, only a single instance can be running at
@@ -13,6 +13,14 @@ export class DisposableSingleApplication implements AsyncDisposable {
   public async startNextAndKillCurrent(startNext: () => Promise<StartableApplication>): Promise<void> {
     await this[Symbol.asyncDispose]()
     this.application = await startNext()
+  }
+
+  public async untilExit(): Promise<ExitInfo> {
+    assert(
+      this.application,
+      "The application not started yet. It makes no sense to wait for it to exit, so this looks like a bug."
+    )
+    return this.application.untilExit
   }
 
   public async write(input: string): Promise<void> {


### PR DESCRIPTION
Issue
=====

Sometimes when starting the test run, the neovim dependencies (plugins and such) are not installed yet. This is done automatically when neovim starts, but it can be slow. This can cause the tests to fail because they depend on the plugins.

Solution
========

Add a new command to `tui neovim exec '<ex-command>'` that will run the given ex-command in a headless neovim instance before starting the tests.

This can be used to initialize the plugins with
`tui neovim exec "Lazy! sync"`