### PR TITLE
fix: throw error on Cypress fail

### DIFF
--- a/packages/integration-tests/cypress/support/tui-sandbox.ts
+++ b/packages/integration-tests/cypress/support/tui-sandbox.ts
@@ -71,9 +71,10 @@ Cypress.Commands.add("runExCommand", (input: ExCommandClientInput) => {
 
 let testWindow: Window | undefined
 
-Cypress.on("fail", async () => {
+Cypress.on("fail", async error => {
   assert(testWindow, "testWindow is not defined")
   await testWindow.runExCommand({ command: "messages", log: true })
+  throw error
 })
 
 before(function () {

--- a/packages/library/src/server/cypress-support/contents.test.ts
+++ b/packages/library/src/server/cypress-support/contents.test.ts
@@ -76,9 +76,10 @@ it("should return the expected contents", async () => {
 
     let testWindow: Window | undefined
 
-    Cypress.on("fail", async () => {
+    Cypress.on("fail", async error => {
       assert(testWindow, "testWindow is not defined")
       await testWindow.runExCommand({ command: "messages", log: true })
+      throw error
     })
 
     before(function () {

--- a/packages/library/src/server/cypress-support/contents.ts
+++ b/packages/library/src/server/cypress-support/contents.ts
@@ -79,9 +79,10 @@ Cypress.Commands.add("runExCommand", (input: ExCommandClientInput) => {
 
 let testWindow: Window | undefined
 
-Cypress.on("fail", async () => {
+Cypress.on("fail", async error => {
   assert(testWindow, "testWindow is not defined")
   await testWindow.runExCommand({ command: "messages", log: true })
+  throw error
 })
 
 before(function () {


### PR DESCRIPTION
Previously, the cypress fail handler was used to log neovim output to the console so that it's visible in the ci test output.

However, not throwing the error means the test can never fail.

Fix this by throwing the error after logging the output.