### PR TITLE
fix: not correctly failing tests

### DIFF
--- a/packages/integration-tests/cypress/e2e/neovim.cy.ts
+++ b/packages/integration-tests/cypress/e2e/neovim.cy.ts
@@ -190,6 +190,14 @@ describe("neovim features", () => {
     })
   })
 
+  it("can show messages after a test fails", () => {
+    cy.visit("/")
+    cy.startNeovim().then(() => {
+      cy.runLuaCode({ luaCode: `vim.api.nvim_echo({{"This is a message", "Normal"}}, true, {})` })
+      cy.runExCommand({ command: "echo 'test message'" })
+    })
+  })
+
   it("can runExCommand and get its result", () => {
     cy.visit("/")
     cy.startNeovim().then(() => {

--- a/packages/integration-tests/cypress/support/tui-sandbox.ts
+++ b/packages/integration-tests/cypress/support/tui-sandbox.ts
@@ -14,7 +14,6 @@ import type {
   StartNeovimGenericArguments,
   TestDirectory,
 } from "@tui-sandbox/library/dist/src/server/types"
-import assert from "assert"
 import type { OverrideProperties } from "type-fest"
 import type { MyTestDirectory, MyTestDirectoryFile } from "../../MyTestDirectory"
 
@@ -71,12 +70,6 @@ Cypress.Commands.add("runExCommand", (input: ExCommandClientInput) => {
 
 let testWindow: Window | undefined
 
-Cypress.on("fail", async error => {
-  assert(testWindow, "testWindow is not defined")
-  void testWindow.runExCommand({ command: "messages", log: true })
-  throw error
-})
-
 before(function () {
   // disable Cypress's default behavior of logging all XMLHttpRequests and
   // fetches to the Command Log
@@ -106,3 +99,9 @@ declare global {
     }
   }
 }
+
+afterEach(async () => {
+  if (!testWindow) return
+  debugger
+  await testWindow.runExCommand({ command: "messages", log: true })
+})

--- a/packages/library/src/server/cypress-support/contents.ts
+++ b/packages/library/src/server/cypress-support/contents.ts
@@ -79,12 +79,6 @@ Cypress.Commands.add("runExCommand", (input: ExCommandClientInput) => {
 
 let testWindow: Window | undefined
 
-Cypress.on("fail", async error => {
-  assert(testWindow, "testWindow is not defined")
-  void testWindow.runExCommand({ command: "messages", log: true })
-  throw error
-})
-
 before(function () {
   // disable Cypress's default behavior of logging all XMLHttpRequests and
   // fetches to the Command Log
@@ -114,6 +108,12 @@ declare global {
     }
   }
 }
+
+afterEach(async () => {
+  if (!testWindow) return
+debugger
+  await testWindow.runExCommand({ command: "messages", log: true })
+})
 `
 
   const options = await resolveConfig(__filename)

--- a/packages/library/src/server/neovim/NeovimJavascriptApiClient.ts
+++ b/packages/library/src/server/neovim/NeovimJavascriptApiClient.ts
@@ -22,6 +22,11 @@ export function connectNeovimApi(socketPath: string): Lazy<Promise<NeovimJavascr
       }
     }
 
+    // Prevent neovim node client from monkey patching console.log. It runs in
+    // a separate process entirely, so there doesn't seem to be any benefit to
+    // this.
+    process.env["ALLOW_CONSOLE"] = "1"
+
     return attach({ socket: socketPath })
   })
 }

--- a/packages/library/src/server/neovim/index.ts
+++ b/packages/library/src/server/neovim/index.ts
@@ -175,7 +175,7 @@ export async function runExCommand(options: ExCommandInput): Promise<RunExComman
   try {
     const output = await api.commandOutput(options.command)
     if (options.log) {
-      console.log(`Ex command output: ${output}`)
+      console.log(`:${options.command} output: ${output}`)
     }
     return { value: output }
   } catch (e) {


### PR DESCRIPTION
The log output is now a lot more verbose. I think I'll adjust it a bit later on. For now it's much better to not hide any useful messages in the test output.