### PR TITLE
fix: create cypress/support directory if it doesn't exist

### DIFF
--- a/packages/library/src/server/cypress-support/createCypressSupportFile.test.ts
+++ b/packages/library/src/server/cypress-support/createCypressSupportFile.test.ts
@@ -62,7 +62,7 @@ describe("createCypressSupportFileContents", () => {
     })
 
     expect(result).toBe("updated" satisfies CreateCypressSupportFileResult)
-    expect(mocked.mkdir).toHaveBeenCalledWith("cypress/support/config-modifications")
+    expect(mocked.mkdir).toHaveBeenCalledWith("cypress/support/config-modifications", { recursive: true })
     expect(mocked.mkdir).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/library/src/server/cypress-support/createCypressSupportFile.ts
+++ b/packages/library/src/server/cypress-support/createCypressSupportFile.ts
@@ -27,7 +27,7 @@ export async function createCypressSupportFile({
     console.log(
       `Creating config-modifications directory at ${configModificationsDirectoryPath}. You can put Neovim startup scripts into this directory, and load them when starting your Neovim test.`
     )
-    await mkdir(configModificationsDirectoryPath)
+    await mkdir(configModificationsDirectoryPath, { recursive: true })
   }
 
   const text = await createCypressSupportFileContents()


### PR DESCRIPTION
This only helps when initializing a new project