### PR TITLE
fix: trying to get neovim messages in a terminal test

### DIFF
--- a/packages/integration-tests/cypress/support/tui-sandbox.ts
+++ b/packages/integration-tests/cypress/support/tui-sandbox.ts
@@ -160,5 +160,6 @@ afterEach(async () => {
     await Promise.race([timeout, testNeovim.runExCommand({ command: "messages" })])
   } finally {
     clearTimeout(timeoutId) // Ensure the timeout is cleared
+    testNeovim = undefined
   }
 })

--- a/packages/library/src/server/cypress-support/contents.ts
+++ b/packages/library/src/server/cypress-support/contents.ts
@@ -168,6 +168,7 @@ afterEach(async () => {
     await Promise.race([timeout, testNeovim.runExCommand({ command: "messages" })])
   } finally {
     clearTimeout(timeoutId) // Ensure the timeout is cleared
+    testNeovim = undefined
   }
 })
 `


### PR DESCRIPTION
If the previous test was a neovim test, and the current test is a terminal test, tui-sandbox would still try to get the messages output from the (already closed) neovim instance.