### PR TITLE
ci: don't report an error to console when downloading an LSP

### DIFF
--- a/packages/integration-tests/test-environment/.config/nvim/prepare.lua
+++ b/packages/integration-tests/test-environment/.config/nvim/prepare.lua
@@ -24,4 +24,4 @@ require("mason-lspconfig").setup({
 
 -- TODO this seems to report some minor error but it works after that. Should
 -- clean this up, though.
-vim.cmd("LspInstall lua_ls@3.13.5")
+vim.cmd("MasonInstall lua_ls@3.13.5")


### PR DESCRIPTION
The following error was reported:

```rs
[server] Fetching available versions...
[server] Downloading file "https://github.com/luals/lua-language-server/releases/download/3.13.5/lua-language-server-3.13.5-darwin-arm64.tar.gz"...
[server] Unpacking "lua-language-server-3.13.5-darwin-arm64.tar.gz"...
[server] Downloading LSP configuration schema from "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/package.json"...
[server] Error detected while processing command line:
[server] E5108: Error executing lua vim/_editor.lua:0: command line..script nvim_exec2() called at command line:0: Vim:x LICENSE
[server] stack traceback:
[server]        [C]: in function 'nvim_exec2'
[server]        vim/_editor.lua: in function 'cmd'
[server]        ...environment/testdirs/dir-TO1YMG/.config/nvim/prepare.lua:27: in main chunk
[server]        [C]: in function 'dofile'
[server]        [string ":lua"]:1: in main chunkFeb 20 19:14:47.293 ERROR Error: Process exited with error code 1
[server] Child process 49765 (nvim) exited with code 1 and signal 0
[server] Killing current application 49765...
[server] 💣 Killing process 49765
[server] 💥 Killed process 49765
```