### PR TITLE
fix: neovim client requests sometimes blocking indefinitely

### DIFF
--- a/packages/library/src/server/server.ts
+++ b/packages/library/src/server/server.ts
@@ -9,6 +9,7 @@ import * as terminal from "./terminal/index.js"
 import { TestServer } from "./TestServer.js"
 import type { DirectoriesConfig, TestServerConfig } from "./updateTestdirectorySchemaFile.js"
 import { tabIdSchema } from "./utilities/tabId.js"
+import { timeoutable } from "./utilities/timeoutable.js"
 
 const luaCodeInputSchema = z.object({ tabId: tabIdSchema, luaCode: z.string() })
 export type LuaCodeClientInput = Except<LuaCodeInput, "tabId">
@@ -104,11 +105,11 @@ export async function createAppRouter(config: DirectoriesConfig) {
       }),
 
       runLuaCode: trpc.procedure.input(luaCodeInputSchema).mutation(options => {
-        return neovim.runLuaCode(options.input)
+        return timeoutable(10_000, neovim.runLuaCode(options.input))
       }),
 
       runExCommand: trpc.procedure.input(exCommandInputSchema).mutation(options => {
-        return neovim.runExCommand(options.input)
+        return timeoutable(10_000, neovim.runExCommand(options.input))
       }),
     }),
   })

--- a/packages/library/src/server/utilities/timeoutable.ts
+++ b/packages/library/src/server/utilities/timeoutable.ts
@@ -1,0 +1,15 @@
+export async function timeoutable<T>(ms: number, promise: Promise<T>): Promise<T> {
+  let timeoutId: NodeJS.Timeout | undefined = undefined
+  const timeout = new Promise<void>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error(`Timeout after ${ms}ms`))
+    }, ms)
+  })
+
+  try {
+    await Promise.race([timeout, promise])
+    return await promise
+  } finally {
+    clearTimeout(timeoutId) // Ensure the timeout is cleared
+  }
+}


### PR DESCRIPTION
Issue
=====

If an error message is currently being displayed in neovim, the client requests will block indefinitely.

Example:
https://github.com/mikavilpas/blink-ripgrep.nvim/actions/runs/13613169822/job/38052846391?pr=152

Solution
========

Add a timeout to the client requests. For now, it's not possible to configure the timeout, but that can be added later on if needed.