### PR TITLE
fix!: allow waiting for neovim dependencies to be installed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,9 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v6.7.16
         with:
-          command: pnpm cy:run
+          command: |
+            pnpm tui neovim prepare
+            pnpm cy:run
 
       - uses: actions/upload-artifact@v4.6.1
         # add the line below to store screenshots only on failures

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,9 @@ jobs:
           cache: "pnpm"
 
       - run: |
-          # install dependencies so we can build the project
+          # install dependencies, which will also build the project
           pnpm install
-          pnpm build
-          # install the "tui" command so it's available for the next steps
-          pnpm install
+          (cd packages/integration-tests && pnpm tui neovim prepare)
 
       - run: pnpm test
       # need to work around https://github.com/cypress-io/github-action/issues/1246
@@ -41,7 +39,6 @@ jobs:
         uses: cypress-io/github-action@v6.7.16
         with:
           command: |
-            pnpm tui neovim prepare
             pnpm cy:run
 
       - uses: actions/upload-artifact@v4.6.1

--- a/packages/integration-tests/test-environment/.config/nvim/prepare.lua
+++ b/packages/integration-tests/test-environment/.config/nvim/prepare.lua
@@ -15,13 +15,11 @@ vim.cmd("Lazy! sync")
 --
 -- The recommendation is to add a specific version to avoid issues in the
 -- future
-require("mason")
-require("mason-lspconfig").setup({
-  -- TODO why does automatic_installation not work?
-  -- ensure_installed = { "lua_ls@3.13.5" },
-  -- automatic_installation = true,
-})
 
--- TODO this seems to report some minor error but it works after that. Should
--- clean this up, though.
-vim.cmd("LspInstall lua_ls@3.13.5")
+-- NOTE: installing mason packages seems to report errors in headless mode, but
+-- it seems to install the package anyway
+-- https://github.com/williamboman/mason.nvim/issues/960#issuecomment-1528081759
+require("mason-registry").refresh()
+
+local command = require("mason.api.command")
+command.MasonInstall({ "lua-language-server" }, { version = "3.13.5" })

--- a/packages/library/src/scripts/tui.ts
+++ b/packages/library/src/scripts/tui.ts
@@ -3,6 +3,7 @@ import path from "node:path"
 import { createCypressSupportFile } from "../server/cypress-support/createCypressSupportFile.js"
 import type { TestServerConfig } from "../server/index.js"
 import { startTestServer, updateTestdirectorySchemaFile } from "../server/index.js"
+import { installDependencies } from "../server/neovim/index.js"
 import type { StdoutOrStderrMessage } from "../server/neovim/NeovimApplication.js"
 import { NeovimApplication } from "../server/neovim/NeovimApplication.js"
 import { prepareNewTestDirectory } from "../server/neovim/prepareNewTestDirectory.js"
@@ -28,6 +29,15 @@ const config = {
 const args = process.argv.slice(2)
 
 if (args[0] === "neovim") {
+  if (args[1] === "prepare" && args.length === 2) {
+    console.log("🚀 Installing neovim dependencies...")
+    await installDependencies(config.directories.testEnvironmentPath, config.directories).catch((err: unknown) => {
+      console.error("Error installing neovim dependencies", err)
+      process.exit(1)
+    })
+    process.exit(0)
+  }
+
   if (!(args[1] === "exec" && args.length === 3)) {
     showUsageAndExit()
   }

--- a/packages/library/src/server/server.ts
+++ b/packages/library/src/server/server.ts
@@ -132,26 +132,14 @@ export async function createAppRouter(config: DirectoriesConfig) {
 export type AppRouter = Awaited<ReturnType<typeof createAppRouter>>
 export type RouterInput = inferRouterInputs<AppRouter>
 
-export async function startTestServer(config: TestServerConfig): Promise<TestServer> {
+export async function startTestServer(config: TestServerConfig): Promise<void> {
   try {
     const testServer = new TestServer({
       port: config.port,
     })
     const appRouter = await createAppRouter(config.directories)
 
-    const neovimTask: Promise<void> = neovim
-      .installDependencies(config.directories.testEnvironmentPath, config.directories)
-      .catch((err: unknown) => {
-        console.error("Error installing neovim dependencies", err)
-        // suppress the error because neovim is optional - other applications
-        // can still be tested
-      })
-
-    const startServerTask = testServer.startAndRun(appRouter)
-
-    await Promise.all([neovimTask, startServerTask])
-
-    return testServer
+    await testServer.startAndRun(appRouter)
   } catch (err: unknown) {
     console.error("Error starting test server", err)
     throw err


### PR DESCRIPTION
BREAKING CHANGE: Neovim dependencies are no longer installed automatically when starting the test server. Instead, you must run `pnpm tui neovim prepare` before starting the test server. Make sure you have your preparation script in place in
`path/to/your/integration-tests/test-environment/.config/nvim/prepare.lua` before doing this.

Issue
=====

The test server starts running the tests before the neovim dependencies have finished installing. This is difficult to see but can be seen here https://github.com/mikavilpas/yazi.nvim/actions/runs/13741224999/job/38439620956#step:11:4772

Solution
========

Add a new command to the TUI script that installs the neovim dependencies. This command must be run before starting the test server.

This will avoid the problem, and I think it will make things clearer for the user as well.