### PR TITLE
chore: make sure the library is built before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "vitest": "3.0.8",
     "wait-on": "8.0.3"
   },
-  "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b",
+  "packageManager": "pnpm@10.6.3+sha512.bb45e34d50a9a76e858a95837301bfb6bd6d35aea2c5d52094fa497a467c43f5c440103ce2511e9e0a2f89c3d6071baac3358fc68ac6fb75e2ceb3d2736065e6",
   "pnpm": {
     "onlyBuiltDependencies": [
       "core-js",

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -11,6 +11,7 @@
     "dev": "concurrently --names 'client,server' 'pnpm dev:client' 'pnpm dev:server' --prefix-colors blue,green",
     "dev:client": "vite",
     "dev:server": "cd ../integration-tests/ && nodemon --watch ../library --ext '*' --exec 'tsx ../library/src/scripts/tui.ts start'",
+    "prepare": "pnpm build",
     "test": "vitest"
   },
   "dependencies": {


### PR DESCRIPTION
# chore: make sure the library is built before publishing

This might fix the following issue that happens when cloning and
installing the project for the first time:

```sh
 WARN  Failed to create bin at /private/var/folders/23/y7gf7hz129l56_83w_g49jl80000gn/T/tmp.bOPvYTQi1t/tui-sandbox/packages/integration-tests/node_modules/.bin/tui. ENOENT: no such file or directory, open '/private/var/folders/23/y7gf7hz129l56_83w_g49jl80000gn/T/tmp.bOPvYTQi1t/tui-sandbox/packages/integration-tests/node_modules/@tui-sandbox/library/dist/src/scripts/tui.js'
Done in 9.3s using pnpm v10.5.2
```

# chore: bump pnpm from 10.5.2 to 10.6.3

