### PR TITLE
feat: add nvim_isRunning command to check if neovim is running

### DIFF
--- a/packages/integration-tests/cypress/e2e/neovim.cy.ts
+++ b/packages/integration-tests/cypress/e2e/neovim.cy.ts
@@ -289,6 +289,17 @@ describe("neovim features", () => {
   })
 })
 
+describe("nvim_isRunning", () => {
+  it("can report whether nvim_isRunning", () => {
+    cy.visit("/")
+    cy.nvim_isRunning().should("be.false")
+
+    cy.startNeovim().then(() => {
+      cy.nvim_isRunning().should("be.true")
+    })
+  })
+})
+
 {
   // @ts-expect-error cwdRelative should only allow MyTestDirectoryFile paths
   const invalid: MyBlockingCommandClientInput["cwdRelative"] = "invalid-invalid"

--- a/packages/integration-tests/cypress/support/tui-sandbox.ts
+++ b/packages/integration-tests/cypress/support/tui-sandbox.ts
@@ -117,6 +117,12 @@ Cypress.Commands.add("startNeovim", (startArguments?: MyStartNeovimServerArgumen
   })
 })
 
+Cypress.Commands.add("nvim_isRunning", () => {
+  return cy.window().then(async _ => {
+    return !!testNeovim
+  })
+})
+
 Cypress.Commands.add("startTerminalApplication", (args: StartTerminalGenericArguments) => {
   cy.window().then(async win => {
     const terminal: GenericTerminalBrowserApi = await win.startTerminalApplication(args)
@@ -180,6 +186,10 @@ declare global {
        * @example "echo expand('%:.')" current file, relative to the cwd
        */
       nvim_runExCommand(input: ExCommandClientInput): Chainable<RunExCommandOutput>
+
+      /** Returns true if neovim is running. Useful to conditionally run
+       * afterEach actions based on whether it's running. */
+      nvim_isRunning(): Chainable<boolean>
 
       terminal_runBlockingShellCommand(input: MyBlockingCommandClientInput): Chainable<BlockingShellCommandOutput>
     }

--- a/packages/library/src/server/cypress-support/contents.ts
+++ b/packages/library/src/server/cypress-support/contents.ts
@@ -125,6 +125,12 @@ Cypress.Commands.add("startNeovim", (startArguments?: MyStartNeovimServerArgumen
   })
 })
 
+Cypress.Commands.add("nvim_isRunning", () => {
+  return cy.window().then(async _ => {
+    return !!testNeovim
+  })
+})
+
 Cypress.Commands.add("startTerminalApplication", (args: StartTerminalGenericArguments) => {
   cy.window().then(async win => {
     const terminal: GenericTerminalBrowserApi = await win.startTerminalApplication(args)
@@ -188,6 +194,10 @@ declare global {
        * @example "echo expand('%:.')" current file, relative to the cwd
        */
       nvim_runExCommand(input: ExCommandClientInput): Chainable<RunExCommandOutput>
+
+      /** Returns true if neovim is running. Useful to conditionally run
+       * afterEach actions based on whether it's running. */
+      nvim_isRunning(): Chainable<boolean>
 
       terminal_runBlockingShellCommand(input: MyBlockingCommandClientInput): Chainable<BlockingShellCommandOutput>
     }


### PR DESCRIPTION
This is useful when tests are too flaky and need to be left out of CI, but can still be run locally on the developers' machines to offer some benefits.

In such a case, using afterEach hooks might not be possible, because they will often rely on neovim having been started.