### PR TITLE
perf: use zod v4 beta for faster type checking

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -32,7 +32,7 @@
     "tsx": "4.19.3",
     "type-fest": "4.39.1",
     "winston": "3.17.0",
-    "zod": "3.24.2"
+    "zod": "4.0.0-beta.20250412T085909"
   },
   "devDependencies": {
     "@types/command-exists": "1.2.3",

--- a/packages/library/src/server/blockingCommandInputSchema.test.ts
+++ b/packages/library/src/server/blockingCommandInputSchema.test.ts
@@ -11,13 +11,15 @@ describe("blockingCommandInputSchema", () => {
     } satisfies Partial<BlockingCommandInput>)
 
     expect(fails.error).toMatchInlineSnapshot(`
-      [ZodError: [
-        {
-          "code": "custom",
-          "message": "Both cwd and cwdRelative provided. Please provide either but not both at the same time.",
-          "path": []
-        }
-      ]]
+      ZodError {
+        "issues": [
+          {
+            "code": "custom",
+            "message": "Both cwd and cwdRelative provided. Please provide either but not both at the same time.",
+            "path": [],
+          },
+        ],
+      }
     `)
   })
 })

--- a/packages/library/src/server/blockingCommandInputSchema.ts
+++ b/packages/library/src/server/blockingCommandInputSchema.ts
@@ -13,7 +13,7 @@ export const blockingCommandInputSchema = z
     // absolute cwd
     cwd: z.string().optional(),
     cwdRelative: z.string().optional(),
-    envOverrides: z.record(z.string()).optional(),
+    envOverrides: z.record(z.string(), z.string()).optional(),
     uid: z.number().optional(),
     gid: z.number().optional(),
   })

--- a/packages/library/src/server/server.ts
+++ b/packages/library/src/server/server.ts
@@ -45,7 +45,7 @@ export async function createAppRouter(config: DirectoriesConfig) {
             tabId: tabIdSchema,
             startTerminalArguments: z.object({
               commandToRun: z.array(z.string()),
-              additionalEnvironmentVariables: z.record(z.string()).optional(),
+              additionalEnvironmentVariables: z.record(z.string(), z.string()).optional(),
               terminalDimensions: z.object({
                 cols: z.number(),
                 rows: z.number(),
@@ -88,7 +88,7 @@ export async function createAppRouter(config: DirectoriesConfig) {
                 cols: z.number(),
                 rows: z.number(),
               }),
-              additionalEnvironmentVariables: z.record(z.string()).optional(),
+              additionalEnvironmentVariables: z.record(z.string(), z.string()).optional(),
             }),
           })
         )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,8 +150,8 @@ importers:
         specifier: 3.17.0
         version: 3.17.0
       zod:
-        specifier: 3.24.2
-        version: 3.24.2
+        specifier: 4.0.0-beta.20250412T085909
+        version: 4.0.0-beta.20250412T085909
     devDependencies:
       '@types/command-exists':
         specifier: 1.2.3
@@ -1009,6 +1009,9 @@ packages:
 
   '@xterm/xterm@5.5.0':
     resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
+
+  '@zod/core@0.4.6':
+    resolution: {integrity: sha512-0IeEldTobOdkoJPyINVQgOHlgCWbpozSsDjdcd2+VcxKvf8T+SYLDVk7NKt0XJx3C0ImNXAXh3V3yIw46NJyQA==}
 
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
@@ -3438,6 +3441,9 @@ packages:
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
+  zod@4.0.0-beta.20250412T085909:
+    resolution: {integrity: sha512-W4OjoCnF5XTuljw4X6Hh3Inp45Ug7mmCWzWfFPv+RZcSIAGz7OPqBKOEDtLjfnJAvoxvY3vO0SkxH1zr0Md/Ag==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -4159,6 +4165,8 @@ snapshots:
       '@xterm/xterm': 5.5.0
 
   '@xterm/xterm@5.5.0': {}
+
+  '@zod/core@0.4.6': {}
 
   abbrev@2.0.0:
     optional: true
@@ -7138,5 +7146,9 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.24.2: {}
+
+  zod@4.0.0-beta.20250412T085909:
+    dependencies:
+      '@zod/core': 0.4.6
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
This has been a minor annoyance when working with large schemas, such as schemas generated for MyTestDirectorySchema in big projects. Hopefully this helps, but I have not tested it yet.

In the future, we should eventually move to zod v4 anyway, so it seems like a low risk for a potential benefit.

https://v4.zod.dev/v4