### PR TITLE
refactor(tests): use emmylua-analyzer-rust for lsp tests

### DIFF
--- a/packages/integration-tests/MyTestDirectory.ts
+++ b/packages/integration-tests/MyTestDirectory.ts
@@ -62,6 +62,7 @@ export const MyTestDirectorySchema = z.object({
       name: z.literal("lua-project/"),
       type: z.literal("directory"),
       contents: z.object({
+        ".luarc.json": z.object({ name: z.literal(".luarc.json"), type: z.literal("file") }),
         "config.lua": z.object({ name: z.literal("config.lua"), type: z.literal("file") }),
         "init.lua": z.object({ name: z.literal("init.lua"), type: z.literal("file") }),
       }),
@@ -134,6 +135,7 @@ export const testDirectoryFiles = z.enum([
   "dir with spaces",
   "file.txt",
   "initial-file.txt",
+  "lua-project/.luarc.json",
   "lua-project/config.lua",
   "lua-project/init.lua",
   "lua-project",

--- a/packages/integration-tests/test-environment/.config/nvim/init.lua
+++ b/packages/integration-tests/test-environment/.config/nvim/init.lua
@@ -45,14 +45,7 @@ local plugins = {
       { "williamboman/mason-lspconfig.nvim", opts = {} },
     },
     config = function()
-      ---@diagnostic disable-next-line: missing-fields
-      require("mason-lspconfig").setup({
-        handlers = {
-          lua_ls = function()
-            require("lspconfig")["lua_ls"].setup({})
-          end,
-        },
-      })
+      --
     end,
   },
   { "catppuccin/nvim", name = "catppuccin", priority = 1000 },
@@ -63,3 +56,7 @@ vim.keymap.set("n", "gd", vim.lsp.buf.definition)
 vim.keymap.set("n", "gr", vim.lsp.buf.references)
 
 vim.cmd.colorscheme("catppuccin-macchiato")
+
+-- the config is automatically loaded via the config in nvim-lspconfig
+-- https://github.com/neovim/nvim-lspconfig/pull/3745
+vim.lsp.enable("emmylua_ls")

--- a/packages/integration-tests/test-environment/.config/nvim/prepare.lua
+++ b/packages/integration-tests/test-environment/.config/nvim/prepare.lua
@@ -22,4 +22,4 @@ vim.cmd("Lazy! sync")
 require("mason-registry").refresh()
 
 local command = require("mason.api.command")
-command.MasonInstall({ "lua-language-server" }, { version = "3.13.5" })
+command.MasonInstall({ "emmylua_ls" }, { version = "0.7.1" })

--- a/packages/library/src/server/dirtree/index.test.ts
+++ b/packages/library/src/server/dirtree/index.test.ts
@@ -87,6 +87,7 @@ describe("dirtree", () => {
             name: z.literal("lua-project/"),
             type: z.literal("directory"),
             contents: z.object({
+              ".luarc.json": z.object({ name: z.literal(".luarc.json"), type: z.literal("file") }),
               "config.lua": z.object({ name: z.literal("config.lua"), type: z.literal("file") }),
               "init.lua": z.object({ name: z.literal("init.lua"), type: z.literal("file") }),
             }),
@@ -159,6 +160,7 @@ describe("dirtree", () => {
         "dir with spaces",
         "file.txt",
         "initial-file.txt",
+        "lua-project/.luarc.json",
         "lua-project/config.lua",
         "lua-project/init.lua",
         "lua-project",


### PR DESCRIPTION
It's much faster to start than lua-language-server, practically instant.

With lua-language-server, it took around 2 seconds to run the single lsp test, but with emmylua-analyzer-rust, it takes less than a second (~600ms). The time seems to vary a bit, but it's an improvement nevertheless.

https://github.com/neovim/nvim-lspconfig/pull/3745