### PR TITLE
fix: import path errors in codegen

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,13 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: pnpm/action-setup@v4.1.0
+        with:
+          # https://github.com/pnpm/action-setup?tab=readme-ov-file#use-cache-to-reduce-installation-time
+          run_install: false
       - uses: actions/setup-node@v4.4.0
         with:
           node-version-file: .nvmrc
           cache: "pnpm"
       - run: pnpm install
-      - run: pnpm build
-      - uses: reviewdog/action-eslint@v1.33.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review # Change reporter.
+      - run: pnpm run eslint

--- a/packages/integration-tests/cypress/e2e/terminal.cy.ts
+++ b/packages/integration-tests/cypress/e2e/terminal.cy.ts
@@ -1,4 +1,4 @@
-import type { TestDirsPath } from "@tui-sandbox/library/src/server/neovim/environment/createTempDir"
+import type { TestDirsPath } from "@tui-sandbox/library/src/server/applications/neovim/environment/createTempDir"
 import assert from "assert"
 
 describe("TerminalTestApplication features", () => {

--- a/packages/integration-tests/cypress/support/tui-sandbox.ts
+++ b/packages/integration-tests/cypress/support/tui-sandbox.ts
@@ -7,19 +7,19 @@ import type {
   GenericTerminalBrowserApi,
 } from "@tui-sandbox/library/dist/src/browser/neovim-client"
 import type {
-  ExCommandClientInput,
-  LuaCodeClientInput,
-  PollLuaCodeClientInput,
-} from "@tui-sandbox/library/dist/src/server/server"
-import type {
   BlockingShellCommandOutput,
   RunExCommandOutput,
   RunLuaCodeOutput,
   StartNeovimGenericArguments,
   TestDirectory,
 } from "@tui-sandbox/library/dist/src/server/types"
+import type {
+  ExCommandClientInput,
+  LuaCodeClientInput,
+  PollLuaCodeClientInput,
+} from "@tui-sandbox/library/src/server/applications/neovim/neovimRouter"
+import type { StartTerminalGenericArguments } from "@tui-sandbox/library/src/server/applications/terminal/TerminalTestApplication"
 import type { BlockingCommandClientInput } from "@tui-sandbox/library/src/server/blockingCommandInputSchema"
-import type { StartTerminalGenericArguments } from "@tui-sandbox/library/src/server/terminal/TerminalTestApplication"
 import type { OverrideProperties } from "type-fest"
 import type { MyTestDirectory, MyTestDirectoryFile } from "../../MyTestDirectory"
 

--- a/packages/library/src/server/cypress-support/contents.ts
+++ b/packages/library/src/server/cypress-support/contents.ts
@@ -15,19 +15,19 @@ import type {
   GenericTerminalBrowserApi,
 } from "@tui-sandbox/library/dist/src/browser/neovim-client"
 import type {
-  ExCommandClientInput,
-  LuaCodeClientInput,
-  PollLuaCodeClientInput,
-} from "@tui-sandbox/library/dist/src/server/server"
-import type {
   BlockingShellCommandOutput,
   RunExCommandOutput,
   RunLuaCodeOutput,
   StartNeovimGenericArguments,
   TestDirectory,
 } from "@tui-sandbox/library/dist/src/server/types"
+import type {
+  ExCommandClientInput,
+  LuaCodeClientInput,
+  PollLuaCodeClientInput,
+} from "@tui-sandbox/library/src/server/applications/neovim/neovimRouter"
+import type { StartTerminalGenericArguments } from "@tui-sandbox/library/src/server/applications/terminal/TerminalTestApplication"
 import type { BlockingCommandClientInput } from "@tui-sandbox/library/src/server/blockingCommandInputSchema"
-import type { StartTerminalGenericArguments } from "@tui-sandbox/library/src/server/terminal/TerminalTestApplication"
 import type { OverrideProperties } from "type-fest"
 import type { MyTestDirectory, MyTestDirectoryFile } from "../../MyTestDirectory"
 


### PR DESCRIPTION
# fix: import path errors in codegen

# ci: fix eslint not running in ci

For example, it passed here
https://github.com/mikavilpas/tui-sandbox/actions/runs/15652662630/job/44099459180

But the build currently errors out!

