### PR TITLE
feat: reduce debug related log noise in the terminal

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -126,6 +126,19 @@ export default tseslint.config([
       ],
     },
   },
+  {
+    files: ["packages/library/src/server/**/*.ts"],
+    rules: {
+      "no-restricted-properties": [
+        "error",
+        {
+          object: "console",
+          property: "log",
+          message: 'Use `debuglog` from "node:util" instead.',
+        },
+      ],
+    },
+  },
 
   // should be the last item, https://github.com/prettier/eslint-config-prettier?tab=readme-ov-file#installation
   eslintConfigPrettier,

--- a/packages/integration-tests/MyTestDirectory.ts
+++ b/packages/integration-tests/MyTestDirectory.ts
@@ -108,6 +108,19 @@ export const MyTestDirectorySchema = z.object({
       name: z.literal("symlink-test/"),
       type: z.literal("directory"),
       contents: z.object({
+        a: z.object({
+          name: z.literal("a/"),
+          type: z.literal("directory"),
+          contents: z.object({
+            b: z.object({
+              name: z.literal("b/"),
+              type: z.literal("directory"),
+              contents: z.object({
+                c: z.object({ name: z.literal("c/"), type: z.literal("directory"), contents: z.object({}) }),
+              }),
+            }),
+          }),
+        }),
         "symlink-target.txt": z.object({ name: z.literal("symlink-target.txt"), type: z.literal("file") }),
       }),
     }),
@@ -149,6 +162,9 @@ export const testDirectoryFiles = z.enum([
   "subdirectory/subdirectory-file.txt",
   "subdirectory",
   "symlink-target.txt",
+  "symlink-test/a/b/c",
+  "symlink-test/a/b",
+  "symlink-test/a",
   "symlink-test/symlink-target.txt",
   "symlink-test",
   ".",

--- a/packages/integration-tests/cypress/e2e/terminal.cy.ts
+++ b/packages/integration-tests/cypress/e2e/terminal.cy.ts
@@ -30,7 +30,7 @@ describe("TerminalTestApplication features", () => {
     })
   })
 
-  it("shows an error if the application fails to start", () => {
+  it.only("shows an error if the application fails to start", () => {
     cy.visit("/")
     cy.startTerminalApplication({
       commandToRun: ["thisdoesnotexist"],

--- a/packages/library/src/server/TestServer.ts
+++ b/packages/library/src/server/TestServer.ts
@@ -6,6 +6,7 @@ import express from "express"
 import { accessSync } from "fs"
 import path from "path"
 import { fileURLToPath } from "url"
+import { debuglog } from "util"
 
 export type TestServerSettings = {
   port: number
@@ -13,12 +14,13 @@ export type TestServerSettings = {
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
+const log = debuglog("tui-sandbox.TestServer")
 
 export class TestServer {
   public constructor(private readonly settings: TestServerSettings) {}
 
   public async startAndRun(appRouter: AnyTRPCRouter): Promise<void> {
-    console.log("🚀 Server starting")
+    log("🚀 Server starting")
 
     const app = express()
     app.use(
@@ -39,7 +41,7 @@ export class TestServer {
       } catch (e) {
         // This is normal when developing the tui-sandbox library locally. It
         // should always exist when using it as an npm package, however.
-        console.log(
+        console.warn(
           `⚠️ Warning: Looks like the tui-sandbox root contents directory is not accessible at: ${publicPath}`
         )
       }
@@ -55,16 +57,16 @@ export class TestServer {
 
     const server = app.listen(this.settings.port, "0.0.0.0")
 
-    console.log(`✅ Server listening on port ${this.settings.port}`)
+    console.info(`✅ Server listening on port ${this.settings.port}`)
 
     await Promise.race([once(process, "SIGTERM"), once(process, "SIGINT")])
-    console.log("😴 Shutting down...")
+    log("😴 Shutting down...")
     server.close(error => {
       if (error) {
         console.error("Error closing server", error)
         process.exit(1)
       }
-      console.log("Server closed")
+      log("Server closed")
       process.exit(0)
     })
   }

--- a/packages/library/src/server/applications/neovim/NeovimApplication.ts
+++ b/packages/library/src/server/applications/neovim/NeovimApplication.ts
@@ -202,11 +202,12 @@ export class NeovimApplication implements AsyncDisposable {
 
     try {
       await access(this.state.socketPath)
-      throw new Error(`Socket file ${this.state.socketPath} should have been removed by neovim when it exited.`)
+      console.warn(`Socket file ${this.state.socketPath} should have been removed by neovim when it exited.`)
+      return
     } catch (e) {
       // all good
+    } finally {
+      this.state = undefined
     }
-
-    this.state = undefined
   }
 }

--- a/packages/library/src/server/applications/neovim/NeovimApplication.ts
+++ b/packages/library/src/server/applications/neovim/NeovimApplication.ts
@@ -5,11 +5,14 @@ import { access } from "fs/promises"
 import type { NeovimClient as NeovimApiClient } from "neovim"
 import { tmpdir } from "os"
 import path, { join } from "path"
+import { debuglog } from "util"
 import type { TestDirectory, TestEnvironmentCommonEnvironmentVariables } from "../../types.js"
 import { DisposableSingleApplication } from "../../utilities/DisposableSingleApplication.js"
 import type { Lazy } from "../../utilities/Lazy.js"
 import { TerminalApplication } from "../../utilities/TerminalApplication.js"
 import { connectNeovimApi } from "./NeovimJavascriptApiClient.js"
+
+const log = debuglog("tui-sandbox-neovim-application")
 
 /*
 
@@ -170,7 +173,7 @@ export class NeovimApplication implements AsyncDisposable {
       client: connectNeovimApi(socketPath),
     }
 
-    console.log(`🚀 Started Neovim instance ${processId}`)
+    log(`🚀 Started Neovim instance ${processId}`)
   }
 
   public getEnvironmentVariables(

--- a/packages/library/src/server/applications/neovim/NeovimJavascriptApiClient.ts
+++ b/packages/library/src/server/applications/neovim/NeovimJavascriptApiClient.ts
@@ -4,6 +4,8 @@ import { attach } from "neovim"
 import { createLogger, format, transports } from "winston"
 import { Lazy } from "../../utilities/Lazy.js"
 
+// const log = debuglog("tui-sandbox.neovim.NeovimJavascriptApiClient")
+
 export type NeovimJavascriptApiClient = NeovimApiClient
 
 export type PollingInterval = 100
@@ -28,10 +30,10 @@ export function connectNeovimApi(socketPath: string): Lazy<Promise<NeovimJavascr
     for (let i = 0; i < 100; i++) {
       try {
         await access(socketPath)
-        // console.log(`socket file ${socketPath} created after at attempt ${i + 1}`)
+        // log(`socket file ${socketPath} created after at attempt ${i + 1}`)
         break
       } catch (e) {
-        // console.log(`polling for socket file ${socketPath} to be created (attempt ${i + 1})`)
+        // log(`polling for socket file ${socketPath} to be created (attempt ${i + 1})`)
         await new Promise(resolve => setTimeout(resolve, 100 satisfies PollingInterval))
       }
     }

--- a/packages/library/src/server/applications/neovim/environment/createTempDir.test.ts
+++ b/packages/library/src/server/applications/neovim/environment/createTempDir.test.ts
@@ -35,3 +35,34 @@ it("should create a temp dir with no contents", async () => {
   expect(result.testEnvironmentPath.includes("test-temp-dir-" satisfies TestTempDirPrefix)).toBeTruthy()
   expect(result.testEnvironmentPathRelative.includes("testdirs" satisfies TestDirsPath)).toBeTruthy()
 })
+
+// TODO
+it("should recreate symlink to repo root with correct relative path in temp dir", async () => {
+  using dir = TempDirectory.create()
+
+  // Simulate repo structure: create original symlink pointing to repo root
+  const symlinkDir = nodePath.join(dir.path, "symlink-test/a/b/c")
+  fs.mkdirSync(symlinkDir, { recursive: true })
+
+  const symlinkPath = nodePath.join(symlinkDir, "rename.yazi")
+  const relativeRepoRoot = "../../../../../../.." // adjust if needed
+  fs.symlinkSync(relativeRepoRoot, symlinkPath)
+
+  // Run test helper
+  const result = await createTempDir({
+    testEnvironmentPath: dir.path,
+    outputFilePath: nodePath.join(dir.path, "MyTestDirectory.ts"),
+  })
+
+  // Find copied symlink
+  const copiedSymlinkPath = nodePath.join(result.testEnvironmentPath, "symlink-test/a/b/c/rename.yazi")
+
+  // Ensure the copied symlink exists and still points to repo root from new location
+  const copiedTarget = fs.readlinkSync(copiedSymlinkPath)
+  const resolvedTarget = nodePath.resolve(nodePath.dirname(copiedSymlinkPath), copiedTarget)
+
+  const repoRoot = nodePath.resolve(dir.path) // original dir is at repo root level
+  expect(fs.existsSync(copiedSymlinkPath)).toBe(true)
+  expect(fs.lstatSync(copiedSymlinkPath).isSymbolicLink()).toBe(true)
+  expect(resolvedTarget).toEqual(repoRoot)
+})

--- a/packages/library/src/server/applications/neovim/environment/createTempDir.ts
+++ b/packages/library/src/server/applications/neovim/environment/createTempDir.ts
@@ -4,10 +4,13 @@ import { Type } from "dree"
 import { constants, readdirSync, statSync } from "fs"
 import { access, mkdir, mkdtemp } from "fs/promises"
 import path from "path"
+import { debuglog } from "util"
 import { convertDree, getDirectoryTree } from "../../../dirtree/index.js"
 import type { TestDirectory } from "../../../types.js"
 import type { DirectoriesConfig } from "../../../updateTestdirectorySchemaFile.js"
 import { updateTestdirectorySchemaFile } from "../../../updateTestdirectorySchemaFile.js"
+
+const log = debuglog("tui-sandbox.createTempDir")
 
 export async function createTempDir(config: DirectoriesConfig): Promise<TestDirectory> {
   try {
@@ -21,7 +24,7 @@ export async function createTempDir(config: DirectoriesConfig): Promise<TestDire
 
       execSync(`cp -R '${path.join(config.testEnvironmentPath, entry)}' ${dir}/`)
     })
-    console.log(`Created test directory at ${dir}`)
+    log(`Created test directory at ${dir}`)
 
     const tree = convertDree(getDirectoryTree(dir).dree)
     assert(tree.type === Type.DIRECTORY)

--- a/packages/library/src/server/applications/neovim/prepareNewTestDirectory.ts
+++ b/packages/library/src/server/applications/neovim/prepareNewTestDirectory.ts
@@ -1,14 +1,17 @@
 import { access, mkdir } from "fs/promises"
+import { debuglog } from "util"
 import type { TestDirectory } from "../../types.js"
 import type { DirectoriesConfig } from "../../updateTestdirectorySchemaFile.js"
 import { createTempDir, removeTestDirectories } from "./environment/createTempDir.js"
+
+const log = debuglog("tui-sandbox.neovim.prepareNewTestDirectory")
 
 export async function prepareNewTestDirectory(config: DirectoriesConfig): Promise<TestDirectory> {
   try {
     // if the directory does not exist, create it
     await access(config.testEnvironmentPath)
   } catch {
-    console.log(`Creating testEnvironmentPath directory at ${config.testEnvironmentPath}`)
+    log(`Creating testEnvironmentPath directory at ${config.testEnvironmentPath}`)
     await mkdir(config.testEnvironmentPath, { recursive: true })
   }
 

--- a/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
+++ b/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
@@ -2,10 +2,13 @@ import assert from "assert"
 import { exec } from "child_process"
 import EventEmitter from "events"
 import { join } from "path"
+import { debuglog } from "util"
 import type { TestDirectory, TestEnvironmentCommonEnvironmentVariables } from "../../types.js"
 import { DisposableSingleApplication } from "../../utilities/DisposableSingleApplication.js"
 import { TerminalApplication } from "../../utilities/TerminalApplication.js"
 import type { StdoutOrStderrMessage, TerminalDimensions } from "../neovim/NeovimApplication.js"
+
+const log = debuglog("tui-sandbox.terminal.TerminalTestApplication")
 
 type ResettableState = {
   testDirectory: TestDirectory
@@ -70,7 +73,7 @@ export default class TerminalTestApplication implements AsyncDisposable {
 
     this.state = { testDirectory }
 
-    console.log(`🚀 Started Terminal instance ${processId}`)
+    log(`🚀 Started Terminal instance ${processId}`)
   }
 
   public getEnvironmentVariables(

--- a/packages/library/src/server/applications/terminal/runBlockingShellCommand.ts
+++ b/packages/library/src/server/applications/terminal/runBlockingShellCommand.ts
@@ -1,9 +1,11 @@
 import { exec } from "child_process"
 import "core-js/proposals/async-explicit-resource-management.js"
 import { join } from "path"
-import util from "util"
+import util, { debuglog } from "util"
 import type { BlockingCommandInput } from "../../blockingCommandInputSchema.js"
 import type { BlockingShellCommandOutput, TestDirectory } from "../../types.js"
+
+const log = debuglog("tui-sandbox.terminal.runBlockingShellCommand")
 
 export async function executeBlockingShellCommand(
   testDirectory: TestDirectory,
@@ -30,7 +32,7 @@ export async function executeBlockingShellCommand(
       cwd,
       env,
     })
-    console.log(
+    log(
       `Successfully ran shell blockingCommand (${input.command}) in cwd: '${cwd}' with stdout: ${result.stdout}, stderr: ${result.stderr}`
     )
     return {

--- a/packages/library/src/server/cypress-support/createCypressSupportFile.ts
+++ b/packages/library/src/server/cypress-support/createCypressSupportFile.ts
@@ -1,7 +1,10 @@
 import { readFileSync, writeFileSync } from "fs"
 import { mkdir, stat } from "fs/promises"
 import path from "path"
+import { debuglog } from "util"
 import { createCypressSupportFileContents } from "./contents.js"
+
+const log = debuglog("tui-sandbox.dirtree")
 
 export type CreateCypressSupportFileArgs = {
   cypressSupportDirectoryPath: string
@@ -24,7 +27,7 @@ export async function createCypressSupportFile({
   try {
     await stat(configModificationsDirectoryPath)
   } catch (error) {
-    console.log(
+    console.info(
       `Creating config-modifications directory at ${configModificationsDirectoryPath}. You can put Neovim startup scripts into this directory, and load them when starting your Neovim test.`
     )
     await mkdir(configModificationsDirectoryPath, { recursive: true })
@@ -37,14 +40,14 @@ export async function createCypressSupportFile({
   try {
     oldSchema = readFileSync(outputFilePath, "utf-8")
   } catch (error) {
-    console.log(`No existing cypress support file found at ${outputFilePath}`)
+    console.warn(`No existing cypress support file found at ${outputFilePath}`)
   }
 
   if (oldSchema !== text) {
     // it's important to not write the file if the schema hasn't changed
     // because file watchers will trigger on file changes and we don't want to
     // trigger a build if the schema hasn't changed
-    console.log(`🪛 Writing cypress support file to ${outputFilePath}`)
+    log(`🪛 Writing cypress support file to ${outputFilePath}`)
     writeFileSync(outputFilePath, text)
     return "updated"
   } else {

--- a/packages/library/src/server/dirtree/index.ts
+++ b/packages/library/src/server/dirtree/index.ts
@@ -3,8 +3,10 @@ import { scan, Type } from "dree"
 import { readlinkSync } from "fs"
 import { format, resolveConfig } from "prettier"
 import { fileURLToPath } from "url"
+import { debuglog } from "util"
 import { jsonToZod } from "./json-to-zod.js"
 
+const log = debuglog("tui-sandbox.dirtree")
 type TreeResult = { dree: Dree | undefined; allFiles: Dree[] }
 
 /** Convert a directory tree to a TypeScript type. This is useful for testing
@@ -117,7 +119,7 @@ export async function buildSchemaForDirectoryTree(result: TreeResult, name: stri
 const __filename = fileURLToPath(import.meta.url)
 
 export async function buildTestDirectorySchema(testDirectoryPath: string): Promise<string> {
-  console.log("Building schema for test directory", testDirectoryPath)
+  log("Building schema for test directory", testDirectoryPath)
   const dree = getDirectoryTree(testDirectoryPath)
   let text = await buildSchemaForDirectoryTree(dree, "MyTestDirectory")
 

--- a/packages/library/src/server/updateTestdirectorySchemaFile.ts
+++ b/packages/library/src/server/updateTestdirectorySchemaFile.ts
@@ -1,5 +1,8 @@
 import { readFileSync, writeFileSync } from "fs"
+import { debuglog } from "util"
 import { buildTestDirectorySchema } from "./dirtree/index.js"
+
+const log = debuglog("tui-sandbox.updateTestdirectorySchemaFile")
 
 export type DirectoriesConfig = {
   testEnvironmentPath: string
@@ -23,7 +26,7 @@ export async function updateTestdirectorySchemaFile({
   try {
     oldSchema = readFileSync(outputFilePath, "utf-8")
   } catch (error) {
-    console.log("No existing schema file found, creating a new one")
+    log("No existing schema file found, creating a new one")
   }
 
   if (oldSchema !== newSchema) {

--- a/packages/library/src/server/utilities/DisposableSingleApplication.ts
+++ b/packages/library/src/server/utilities/DisposableSingleApplication.ts
@@ -1,7 +1,10 @@
 import assert from "assert"
+import { debuglog } from "util"
 import type { ExitInfo, TerminalApplication } from "./TerminalApplication.js"
 
 export type StartableApplication = Pick<TerminalApplication, "write" | "processId" | "killAndWait" | "untilExit">
+
+const log = debuglog("tui-sandbox.DisposableSingleApplication")
 
 /** A testable application that can be started, killed, and given input. For a
  * single instance of this interface, only a single instance can be running at
@@ -40,7 +43,7 @@ export class DisposableSingleApplication implements AsyncDisposable {
     if (this.processId() === undefined) {
       return
     }
-    console.log(`Killing current application ${this.processId()}...`)
+    log(`Killing current application ${this.processId()}...`)
     await this.application?.killAndWait()
   }
 }

--- a/packages/library/src/server/utilities/TerminalApplication.ts
+++ b/packages/library/src/server/utilities/TerminalApplication.ts
@@ -4,7 +4,10 @@ import { createLogger, format, transports } from "winston"
 import type { ITerminalDimensions } from "@xterm/addon-fit"
 import type { IPty } from "node-pty"
 import pty from "node-pty"
+import { debuglog } from "util"
 import type { StartableApplication } from "./DisposableSingleApplication.js"
+
+const log = debuglog("tui-sandbox.TerminalApplication")
 
 export type ExitInfo = { exitCode: number; signal: number | undefined }
 
@@ -55,7 +58,7 @@ export class TerminalApplication implements StartableApplication {
     env?: NodeJS.ProcessEnv
     dimensions: ITerminalDimensions
   }): TerminalApplication {
-    console.log(`Starting '${command}' with args '${args.join(" ")}' in cwd '${cwd}'`)
+    log(`Starting '${command}' with args '${args.join(" ")}' in cwd '${cwd}'`)
 
     const ptyProcess = pty.spawn(command, args, {
       name: "xterm-color",
@@ -66,7 +69,7 @@ export class TerminalApplication implements StartableApplication {
     })
     ptyProcess.onData(onStdoutOrStderr)
     ptyProcess.onExit(({ exitCode, signal }) => {
-      console.log(`Child process exited with code ${exitCode} and signal ${signal}`)
+      log(`Child process exited with code ${exitCode} and signal ${signal}`)
     })
 
     const processId = ptyProcess.pid
@@ -90,8 +93,8 @@ export class TerminalApplication implements StartableApplication {
   }
 
   public async killAndWait(): Promise<void> {
-    console.log(`💣 Killing process ${this.processId}`)
+    log(`💣 Killing process ${this.processId}`)
     this.subProcess.kill()
-    console.log(`💥 Killed process ${this.processId}`)
+    log(`💥 Killed process ${this.processId}`)
   }
 }


### PR DESCRIPTION
# feat: reduce debug related log noise in the terminal

**Issue:**

The terminal is flooded with debug logs, making it difficult to read the
output of the tests.

**Solution:**

Disable almost all logs by default. They can be enabled by specifying an
environment variable when starting the terminal:

```sh

NODE_DEBUG=tui-sandbox* pnpm exec tui start
```

This uses the `debuglog` function from Node.js, which allows for
conditional logging based on the `NODE_DEBUG` environment variable:

- https://nodejs.org/api/util.html#utildebuglogsection-callback

