### PR TITLE
fix: don't try to show neovim :messages as they cannot be seen

### DIFF
--- a/packages/integration-tests/cypress/support/tui-sandbox.ts
+++ b/packages/integration-tests/cypress/support/tui-sandbox.ts
@@ -209,20 +209,5 @@ declare global {
 }
 
 afterEach(async () => {
-  if (!testNeovim) return
-
-  let timeoutId: NodeJS.Timeout | undefined = undefined
-  const timeout = new Promise<void>((_, reject) => {
-    timeoutId = setTimeout(() => {
-      Cypress.log({ name: "timeout when waiting for :messages to finish. Neovim might be stuck or showing a message." })
-      reject(new Error("timeout when waiting for :messages to finish. Neovim might be stuck or showing a message."))
-    }, 5_000)
-  })
-
-  try {
-    await Promise.race([timeout, testNeovim.runExCommand({ command: "messages" })])
-  } finally {
-    clearTimeout(timeoutId) // Ensure the timeout is cleared
-    testNeovim = undefined
-  }
+  testNeovim = undefined
 })

--- a/packages/library/src/server/cypress-support/contents.ts
+++ b/packages/library/src/server/cypress-support/contents.ts
@@ -217,22 +217,7 @@ declare global {
 }
 
 afterEach(async () => {
-  if (!testNeovim) return
-
-  let timeoutId: NodeJS.Timeout | undefined = undefined
-  const timeout = new Promise<void>((_, reject) => {
-    timeoutId = setTimeout(() => {
-      Cypress.log({ name: "timeout when waiting for :messages to finish. Neovim might be stuck or showing a message." })
-      reject(new Error("timeout when waiting for :messages to finish. Neovim might be stuck or showing a message."))
-    }, 5_000)
-  })
-
-  try {
-    await Promise.race([timeout, testNeovim.runExCommand({ command: "messages" })])
-  } finally {
-    clearTimeout(timeoutId) // Ensure the timeout is cleared
-    testNeovim = undefined
-  }
+  testNeovim = undefined
 })
 `
 


### PR DESCRIPTION
After https://github.com/mikavilpas/tui-sandbox/pull/478, the output is not shown by default. It makes no sense to try to show it in the afterEach hook, as it will not be visible to the user.

I think it also sometimes blocked the test run despite my attempt to use a timeout. Better to get rid of it.