### PR TITLE
chore: remove clean-install:all script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "type": "module",
   "scripts": {
     "build": "pnpm --recursive build",
-    "clean-install:all": "pnpm ci",
     "cy:run": "pnpm --filter=library build && pnpm --filter integration-tests cy:run",
     "dev": "pnpm --filter integration-tests dev",
     "eslint": "eslint --max-warnings=0 .",


### PR DESCRIPTION
It does not seem to be used