### PR TITLE
feat: can start neovim with a different NVIM_APPNAME

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,11 @@ jobs:
       - run: |
           # install dependencies, which will also build the project
           pnpm install
-          (cd packages/integration-tests && pnpm tui neovim prepare)
+          cd packages/integration-tests
+
+          # NVIM_APPNAME=nvim is the default, but spelled out here for clarity
+          NVIM_APPNAME=nvim pnpm tui neovim prepare
+          NVIM_APPNAME=nvim_alt pnpm tui neovim prepare
 
       - run: pnpm test
       # need to work around https://github.com/cypress-io/github-action/issues/1246

--- a/packages/integration-tests/MyTestDirectory.ts
+++ b/packages/integration-tests/MyTestDirectory.ts
@@ -28,6 +28,14 @@ export const MyTestDirectorySchema = z.object({
             "prepare.lua": z.object({ name: z.literal("prepare.lua"), type: z.literal("file") }),
           }),
         }),
+        nvim_alt: z.object({
+          name: z.literal("nvim_alt/"),
+          type: z.literal("directory"),
+          contents: z.object({
+            "init.lua": z.object({ name: z.literal("init.lua"), type: z.literal("file") }),
+            "prepare.lua": z.object({ name: z.literal("prepare.lua"), type: z.literal("file") }),
+          }),
+        }),
       }),
     }),
     "config-modifications": z.object({
@@ -125,6 +133,9 @@ export const testDirectoryFiles = z.enum([
   ".config/nvim/init.lua",
   ".config/nvim/prepare.lua",
   ".config/nvim",
+  ".config/nvim_alt/init.lua",
+  ".config/nvim_alt/prepare.lua",
+  ".config/nvim_alt",
   ".config",
   "config-modifications/add_command_to_count_open_buffers.lua",
   "config-modifications/add_command_to_update_buffer_after_timeout.lua",

--- a/packages/integration-tests/cypress/e2e/neovim.cy.ts
+++ b/packages/integration-tests/cypress/e2e/neovim.cy.ts
@@ -16,6 +16,18 @@ describe("neovim features", () => {
     })
   })
 
+  it("can start neovim with a different NVIM_APPNAME", () => {
+    cy.visit("/")
+    cy.startNeovim({ NVIM_APPNAME: "nvim_alt" }).then(() => {
+      // wait until text on the start screen is visible
+      cy.contains("If you see this text, Neovim is ready!")
+
+      // this variable only exists in the nvim_alt/init.lua file
+      cy.typeIntoTerminal(":=_G.isInitFileLoaded_alt{enter}")
+      cy.contains("yesTheInitFileIsLoaded")
+    })
+  })
+
   it("can start with startupScriptModifications and open another file", () => {
     cy.visit("/")
     cy.startNeovim({

--- a/packages/integration-tests/test-environment/.config/nvim_alt/init.lua
+++ b/packages/integration-tests/test-environment/.config/nvim_alt/init.lua
@@ -1,0 +1,46 @@
+---@module "lazy"
+
+-- This files defines how to initialize the test environment for the
+-- integration tests. It should be executed before running the tests.
+
+-- this is used in some tests
+_G.isInitFileLoaded_alt = "yesTheInitFileIsLoaded"
+
+-- Bootstrap lazy.nvim
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.uv.fs_stat(lazypath) then
+  local lazyrepo = "https://github.com/folke/lazy.nvim.git"
+  local out = vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "--branch=stable",
+    lazyrepo,
+    lazypath,
+  })
+  if vim.v.shell_error ~= 0 then
+    vim.api.nvim_echo({
+      { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+      { out, "WarningMsg" },
+      { "\nPress any key to exit..." },
+    }, true, {})
+    vim.fn.getchar()
+    os.exit(1)
+  end
+end
+vim.opt.rtp:prepend(lazypath)
+
+-- Make sure to setup `mapleader` and `maplocalleader` before
+-- loading lazy.nvim so that mappings are correct.
+-- This is also a good place to setup other settings (vim.opt)
+vim.g.mapleader = " "
+vim.g.maplocalleader = " "
+vim.o.swapfile = false
+
+require("lazy").setup({
+  ---@type LazySpec
+  { "lewis6991/gitsigns.nvim", opts = {} },
+  { "catppuccin/nvim", name = "catppuccin", priority = 1000 },
+})
+
+vim.cmd.colorscheme("catppuccin-latte")

--- a/packages/integration-tests/test-environment/.config/nvim_alt/prepare.lua
+++ b/packages/integration-tests/test-environment/.config/nvim_alt/prepare.lua
@@ -1,0 +1,2 @@
+-- make sure the dependencies defined in ./init.lua are installed
+vim.cmd("Lazy! sync")

--- a/packages/library/src/browser/neovim-client.ts
+++ b/packages/library/src/browser/neovim-client.ts
@@ -10,6 +10,7 @@ import type {
 import type { StartTerminalGenericArguments } from "../server/applications/terminal/TerminalTestApplication.js"
 import type { BlockingCommandClientInput } from "../server/blockingCommandInputSchema.js"
 import type {
+  AllKeys,
   BlockingShellCommandOutput,
   RunExCommandOutput,
   RunLuaCodeOutput,
@@ -42,7 +43,9 @@ window.startNeovim = async function (startArgs?: StartNeovimGenericArguments): P
     additionalEnvironmentVariables: startArgs?.additionalEnvironmentVariables,
     filename: startArgs?.filename ?? "initial-file.txt",
     startupScriptModifications: startArgs?.startupScriptModifications ?? [],
-  })
+    headlessCmd: undefined,
+    NVIM_APPNAME: startArgs?.NVIM_APPNAME,
+  } satisfies AllKeys<StartNeovimGenericArguments>)
 
   const neovimBrowserApi: GenericNeovimBrowserApi = {
     runBlockingShellCommand(input: BlockingCommandClientInput): Promise<BlockingShellCommandOutput> {

--- a/packages/library/src/client/neovim-terminal-client.ts
+++ b/packages/library/src/client/neovim-terminal-client.ts
@@ -86,10 +86,11 @@ export class NeovimTerminalClient {
         filename: args.filename,
         additionalEnvironmentVariables: args.additionalEnvironmentVariables,
         startupScriptModifications: args.startupScriptModifications,
-        terminalDimensions: {
-          cols: this.terminal.cols,
-          rows: this.terminal.rows,
-        },
+        NVIM_APPNAME: args.NVIM_APPNAME,
+      },
+      terminalDimensions: {
+        cols: this.terminal.cols,
+        rows: this.terminal.rows,
       },
       tabId: this.tabId,
     })

--- a/packages/library/src/scripts/tui.ts
+++ b/packages/library/src/scripts/tui.ts
@@ -30,8 +30,13 @@ const args = process.argv.slice(2)
 
 if (args[0] === "neovim") {
   if (args[1] === "prepare" && args.length === 2) {
-    console.log("🚀 Installing neovim dependencies...")
-    await installDependencies(config.directories.testEnvironmentPath, config.directories).catch((err: unknown) => {
+    const NVIM_APPNAME = process.env["NVIM_APPNAME"]
+    console.log(`🚀 Installing neovim dependencies${NVIM_APPNAME ? ` for NVIM_APPNAME=${NVIM_APPNAME}` : ""}...`)
+    await installDependencies(
+      config.directories.testEnvironmentPath,
+      process.env["NVIM_APPNAME"],
+      config.directories
+    ).catch((err: unknown) => {
       console.error("Error installing neovim dependencies", err)
       process.exit(1)
     })
@@ -54,7 +59,11 @@ if (args[0] === "neovim") {
     const testDirectory = await prepareNewTestDirectory(config.directories)
     await app.startNextAndKillCurrent(
       testDirectory,
-      { filename: "empty.txt", headlessCmd: command },
+      {
+        filename: "empty.txt",
+        headlessCmd: command,
+        NVIM_APPNAME: process.env["NVIM_APPNAME"],
+      },
       { cols: 80, rows: 24 }
     )
     await app.application.untilExit()

--- a/packages/library/src/server/applications/neovim/NeovimApplication.ts
+++ b/packages/library/src/server/applications/neovim/NeovimApplication.ts
@@ -51,9 +51,9 @@ Options:
 
 See ":help startup-options" for all options.
 
-NVIM v0.11.0-dev-1589+g71507281fb
-Build type: RelWithDebInfo
-LuaJIT 2.1.1736781742
+NVIM v0.11.2
+Build type: Release
+LuaJIT 2.1.1741730670
 Run "nvim -V1 -v" for more info
 
 */

--- a/packages/library/src/server/applications/neovim/neovimRouter.ts
+++ b/packages/library/src/server/applications/neovim/neovimRouter.ts
@@ -42,18 +42,19 @@ export function createNeovimRouter(config: DirectoriesConfig) {
               }),
             ]),
             startupScriptModifications: z.array(z.string()).optional(),
-            terminalDimensions: z.object({
-              cols: z.number(),
-              rows: z.number(),
-            }),
             additionalEnvironmentVariables: z.record(z.string(), z.string()).optional(),
+            NVIM_APPNAME: z.string().optional().default("nvim"),
+          }),
+          terminalDimensions: z.object({
+            cols: z.number(),
+            rows: z.number(),
           }),
         })
       )
       .mutation(options => {
         return neovim.start(
           options.input.startNeovimArguments,
-          options.input.startNeovimArguments.terminalDimensions,
+          options.input.terminalDimensions,
           options.input.tabId,
           config
         )

--- a/packages/library/src/server/dirtree/index.test.ts
+++ b/packages/library/src/server/dirtree/index.test.ts
@@ -53,6 +53,14 @@ describe("dirtree", () => {
                   "prepare.lua": z.object({ name: z.literal("prepare.lua"), type: z.literal("file") }),
                 }),
               }),
+              nvim_alt: z.object({
+                name: z.literal("nvim_alt/"),
+                type: z.literal("directory"),
+                contents: z.object({
+                  "init.lua": z.object({ name: z.literal("init.lua"), type: z.literal("file") }),
+                  "prepare.lua": z.object({ name: z.literal("prepare.lua"), type: z.literal("file") }),
+                }),
+              }),
             }),
           }),
           "config-modifications": z.object({
@@ -150,6 +158,9 @@ describe("dirtree", () => {
         ".config/nvim/init.lua",
         ".config/nvim/prepare.lua",
         ".config/nvim",
+        ".config/nvim_alt/init.lua",
+        ".config/nvim_alt/prepare.lua",
+        ".config/nvim_alt",
         ".config",
         "config-modifications/add_command_to_count_open_buffers.lua",
         "config-modifications/add_command_to_update_buffer_after_timeout.lua",


### PR DESCRIPTION
# feat: can start neovim with a different NVIM_APPNAME

**Issue:**

It's not possible to start a Neovim test session with different sets of
plugins and LSP servers installed. Some plugins might look for the
presence of a plugin, and enable or disable features based on that.

However, if a plugin is used in a different test, it will be available
in the environment, and the test will exhibit different behavior than
what would have happened if the plugin was not installed.

**Solution:**

Now it's possible to start Neovim with a different `init.lua`
configuration file by setting the `NVIM_APPNAME` environment variable.

```ts
// loads the file test-environment/.config/nvim_alt/init.lua
cy.startNeovim({ NVIM_APPNAME: "nvim_alt" })

// these load the file test-environment/.config/nvim/init.lua
cy.startNeovim({ NVIM_APPNAME: "nvim" })
cy.startNeovim({}) // default NVIM_APPNAME is "nvim"
```

https://neovim.io/doc/user/starting.html#_nvim_appname

# chore: update nvim version in `nvim --help` comment

The options have not changed though

