### PR TITLE
feat: `nvim.doFile()` command to load a lua file after nvim startup

### DIFF
--- a/packages/integration-tests/cypress/e2e/neovim.cy.ts
+++ b/packages/integration-tests/cypress/e2e/neovim.cy.ts
@@ -268,6 +268,37 @@ describe("neovim features", () => {
     })
   })
 
+  it(`"dofile" can load additional lua files easily after nvim startup`, () => {
+    cy.visit("/")
+
+    cy.startNeovim().then(nvim => {
+      cy.contains("If you see this text, Neovim is ready!")
+
+      // the file should not be loaded yet, meaning the command is not available
+      nvim.runLuaCode({
+        luaCode: `assert(vim.api.nvim_get_commands({})['CountBuffers'] == nil)`,
+      })
+
+      nvim.doFile({
+        luaFile: "config-modifications/add_command_to_count_open_buffers.lua",
+      })
+
+      // the command should now be available
+      nvim.runLuaCode({
+        luaCode: `assert(vim.api.nvim_get_commands({})['CountBuffers'] ~= nil)`,
+      })
+
+      // test some types, no need to run this in the tests though
+      if (1 + 0 === 1337) {
+        nvim.doFile({
+          // @ts-expect-error the file is not listed in MyTestDirectoryFile, so
+          // it should be a type error
+          luaFile: "invalid-file",
+        })
+      }
+    })
+  })
+
   describe("using an LSP server", () => {
     it("can use an LSP server that's already installed", () => {
       // in the test setup, the LSP server is installed in the file

--- a/packages/integration-tests/cypress/support/tui-sandbox.ts
+++ b/packages/integration-tests/cypress/support/tui-sandbox.ts
@@ -20,6 +20,7 @@ import type {
   ExCommandClientInput,
   LuaCodeClientInput,
   PollLuaCodeClientInput,
+  RunLuaFileClientInput,
 } from "@tui-sandbox/library/src/server/applications/neovim/neovimRouter"
 import type { StartTerminalGenericArguments } from "@tui-sandbox/library/src/server/applications/terminal/TerminalTestApplication"
 import type { BlockingCommandClientInput } from "@tui-sandbox/library/src/server/blockingCommandInputSchema"
@@ -53,6 +54,13 @@ export type NeovimContext = {
    * finish before returning. Requires neovim to be running. */
   runLuaCode(input: LuaCodeClientInput): Cypress.Chainable<RunLuaCodeOutput>
 
+  /** Runs a Lua file in neovim after it has started. Can be used to keep
+   * complex lua logic in a separate file, still being able to run it after
+   * startup. This way additional tools like lua LSP servers, linters, etc. can
+   * be used to ensure the code is correct.
+   */
+  doFile(input: MyRunLuaFileClientInput): Cypress.Chainable<RunExCommandOutput>
+
   /**
    * Like runLuaCode, but waits until the given code (maybe using lua's return
    * assert()) does not raise an error, and returns the first successful result.
@@ -82,6 +90,8 @@ export type MyStartNeovimServerArguments = OverrideProperties<
   }
 >
 
+export type MyRunLuaFileClientInput = OverrideProperties<RunLuaFileClientInput, { luaFile: MyTestDirectoryFile }>
+
 Cypress.Commands.add("startNeovim", (startArguments?: MyStartNeovimServerArguments) => {
   cy.window().then(async win => {
     const underlyingNeovim: GenericNeovimBrowserApi = await win.startNeovim(
@@ -95,6 +105,7 @@ Cypress.Commands.add("startNeovim", (startArguments?: MyStartNeovimServerArgumen
       nvim_runExCommand: underlyingNeovim.runExCommand,
       nvim_runLuaCode: underlyingNeovim.runLuaCode,
       nvim_waitForLuaCode: underlyingNeovim.waitForLuaCode,
+      nvim_doFile: underlyingNeovim.doFile,
     })
 
     const api: NeovimContext = {
@@ -106,6 +117,9 @@ Cypress.Commands.add("startNeovim", (startArguments?: MyStartNeovimServerArgumen
       },
       runLuaCode(input) {
         return cy.nvim_runLuaCode(input)
+      },
+      doFile(input) {
+        return cy.nvim_doFile(input)
       },
       waitForLuaCode(input) {
         return cy.nvim_waitForLuaCode(input)
@@ -193,6 +207,7 @@ declare global {
       nvim_runBlockingShellCommand(input: MyBlockingCommandClientInput): Chainable<BlockingShellCommandOutput>
 
       nvim_runLuaCode(input: LuaCodeClientInput): Chainable<RunLuaCodeOutput>
+      nvim_doFile(input: MyRunLuaFileClientInput): Chainable<RunExCommandOutput>
       nvim_waitForLuaCode(input: PollLuaCodeClientInput): Chainable<RunLuaCodeOutput>
 
       /** Run an ex command in neovim.

--- a/packages/library/src/browser/neovim-client.ts
+++ b/packages/library/src/browser/neovim-client.ts
@@ -6,6 +6,7 @@ import type {
   ExCommandClientInput,
   LuaCodeClientInput,
   PollLuaCodeClientInput,
+  RunLuaFileClientInput,
 } from "../server/applications/neovim/neovimRouter.js"
 import type { StartTerminalGenericArguments } from "../server/applications/terminal/TerminalTestApplication.js"
 import type { BlockingCommandClientInput } from "../server/blockingCommandInputSchema.js"
@@ -31,6 +32,7 @@ const terminalClient = new Lazy(() => new TerminalTerminalClient(app))
 export type GenericNeovimBrowserApi = {
   runBlockingShellCommand(input: BlockingCommandClientInput): Promise<BlockingShellCommandOutput>
   runLuaCode(input: LuaCodeClientInput): Promise<RunLuaCodeOutput>
+  doFile(input: RunLuaFileClientInput): Promise<RunLuaCodeOutput>
   waitForLuaCode(input: PollLuaCodeClientInput): Promise<RunLuaCodeOutput>
   runExCommand(input: ExCommandClientInput): Promise<RunExCommandOutput>
   dir: TestDirectory
@@ -53,6 +55,9 @@ window.startNeovim = async function (startArgs?: StartNeovimGenericArguments): P
     },
     runLuaCode(input) {
       return neovim.runLuaCode(input)
+    },
+    doFile(input) {
+      return neovim.doFile(input)
     },
     waitForLuaCode(input) {
       return neovim.waitForLuaCode(input)

--- a/packages/library/src/client/neovim-terminal-client.ts
+++ b/packages/library/src/client/neovim-terminal-client.ts
@@ -5,6 +5,7 @@ import type {
   ExCommandClientInput,
   LuaCodeClientInput,
   PollLuaCodeClientInput,
+  RunLuaFileClientInput,
 } from "../server/applications/neovim/neovimRouter.js"
 import type { BlockingCommandClientInput } from "../server/blockingCommandInputSchema.js"
 import type { AppRouter } from "../server/server.js"
@@ -106,6 +107,15 @@ export class NeovimTerminalClient {
   public async runLuaCode(input: LuaCodeClientInput): Promise<RunLuaCodeOutput> {
     await this.ready
     return this.trpc.neovim.runLuaCode.mutate({ ...input, tabId: this.tabId })
+  }
+
+  public async doFile(input: RunLuaFileClientInput): Promise<RunExCommandOutput> {
+    await this.ready
+    return this.trpc.neovim.runExCommand.mutate({
+      ...input,
+      tabId: this.tabId,
+      command: `lua dofile("${input.luaFile}")`,
+    })
   }
 
   public async waitForLuaCode(input: PollLuaCodeClientInput): Promise<RunLuaCodeOutput> {

--- a/packages/library/src/server/applications/neovim/neovimRouter.ts
+++ b/packages/library/src/server/applications/neovim/neovimRouter.ts
@@ -26,6 +26,14 @@ const exCommandInputSchema = z.object({
 export type ExCommandClientInput = Except<ExCommandInput, "tabId">
 export type ExCommandInput = z.infer<typeof exCommandInputSchema>
 
+const runLuaFileInputSchema = z.object({
+  tabId: tabIdSchema,
+  luaFile: z.string(),
+  log: z.boolean().optional(),
+})
+export type RunLuaFileInput = z.output<typeof runLuaFileInputSchema>
+export type RunLuaFileClientInput = Except<RunLuaFileInput, "tabId">
+
 // let trpc infer the type as that is what it is designed to do
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function createNeovimRouter(config: DirectoriesConfig) {


### PR DESCRIPTION
This works great for tests that need to test the following type of scenario:

- Neovim is started
- make sure an optional feature is not enabled yet
- load a lua file that enables the feature
- make sure the feature is now enabled

https://neovim.io/doc/user/luaref.html#dofile()