### PR TITLE
fix: rendering emoji as truncated images

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -23,6 +23,7 @@
     "@trpc/client": "11.4.3",
     "@trpc/server": "11.4.3",
     "@xterm/addon-fit": "0.10.0",
+    "@xterm/addon-unicode11": "0.8.0",
     "@xterm/xterm": "5.5.0",
     "cors": "2.8.5",
     "dree": "5.1.5",

--- a/packages/library/src/client/startTerminal.ts
+++ b/packages/library/src/client/startTerminal.ts
@@ -1,5 +1,6 @@
 import { flavors } from "@catppuccin/palette"
 import { FitAddon } from "@xterm/addon-fit"
+import { Unicode11Addon } from "@xterm/addon-unicode11"
 import { Terminal } from "@xterm/xterm"
 import "@xterm/xterm/css/xterm.css"
 import * as z from "zod"
@@ -13,6 +14,7 @@ export type TuiTerminalApi = {
 }
 export function startTerminal(app: HTMLElement, api: TuiTerminalApi): Terminal {
   const terminal = new Terminal({
+    allowProposedApi: true,
     cursorBlink: false,
     convertEol: true,
     fontSize: 13,
@@ -42,6 +44,13 @@ export function startTerminal(app: HTMLElement, api: TuiTerminalApi): Terminal {
   // page in this case
   const fitAddon = new FitAddon()
   terminal.loadAddon(fitAddon)
+
+  // The Unicode11Addon fixes emoji rendering issues. Without it, emoji are
+  // displayed as truncated (partial) images.
+  const unicode11Addon = new Unicode11Addon()
+  terminal.loadAddon(unicode11Addon)
+  terminal.unicode.activeVersion = "11"
+
   terminal.open(app)
   fitAddon.fit()
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@xterm/addon-fit':
         specifier: 0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/addon-unicode11':
+        specifier: 0.8.0
+        version: 0.8.0(@xterm/xterm@5.5.0)
       '@xterm/xterm':
         specifier: 5.5.0
         version: 5.5.0
@@ -1047,6 +1050,11 @@ packages:
 
   '@xterm/addon-fit@0.10.0':
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/addon-unicode11@0.8.0':
+    resolution: {integrity: sha512-LxinXu8SC4OmVa6FhgwsVCBZbr8WoSGzBl2+vqe8WcQ6hb1r6Gj9P99qTNdPiFPh4Ceiu2pC8xukZ6+2nnh49Q==}
     peerDependencies:
       '@xterm/xterm': ^5.0.0
 
@@ -4257,6 +4265,10 @@ snapshots:
       tinyrainbow: 2.0.0
 
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/addon-unicode11@0.8.0(@xterm/xterm@5.5.0)':
     dependencies:
       '@xterm/xterm': 5.5.0
 


### PR DESCRIPTION
**Issue:**

In neovim, displaying an emoji such as 🎉 is displayed as a double-width character with part of the second half missing, resulting in a truncated image.

Neovim is able to display emoji perfectly fine outside of xterm.js.

**Solution:**

Add the `@xterm/addon-unicode11` addon to xterm.js, which fixes the emoji rendering issue by enabling Unicode 11 support.