### PR TITLE
ci: test `pnpm tui neovim exec version` in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,9 @@ jobs:
           NVIM_APPNAME=nvim pnpm tui neovim prepare
           NVIM_APPNAME=nvim_alt pnpm tui neovim prepare
 
+          # test that tui neovim exec works
+          pnpm tui neovim exec version
+
       - run: pnpm test
       # need to work around https://github.com/cypress-io/github-action/issues/1246
       - run: pnpm --filter integration-tests exec cypress install


### PR DESCRIPTION
Add a simple command that runs really fast, but tests that the `tui neovim exec` command works end-to-end in the CI environment.