### PR TITLE
refactor: don't use vitest globals in tests

### DIFF
--- a/packages/library/src/client/MyNeovimConfigModification.test.ts
+++ b/packages/library/src/client/MyNeovimConfigModification.test.ts
@@ -1,3 +1,4 @@
+import { assertType, it } from "vitest"
 import * as z from "zod"
 import type { MyNeovimConfigModification } from "./MyNeovimConfigModification.js"
 

--- a/packages/library/src/client/color-utilities.test.ts
+++ b/packages/library/src/client/color-utilities.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest"
 import type { RgbColor } from "./color-utilities.js"
 import { rgbify } from "./color-utilities.js"
 

--- a/packages/library/src/scripts/parseArguments.test.ts
+++ b/packages/library/src/scripts/parseArguments.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest"
 import { parseArguments } from "./parseArguments.js"
 
 it(`can parse "neovim prepare"`, async () => {

--- a/packages/library/src/server/applications/neovim/NeovimJavascriptApiClient.test.ts
+++ b/packages/library/src/server/applications/neovim/NeovimJavascriptApiClient.test.ts
@@ -1,5 +1,6 @@
 import { access } from "fs/promises"
 import { attach } from "neovim"
+import { afterEach, beforeEach, expect, it, vi } from "vitest"
 import type { PollingInterval } from "./NeovimJavascriptApiClient.js"
 import { connectNeovimApi } from "./NeovimJavascriptApiClient.js"
 

--- a/packages/library/src/server/applications/neovim/environment/createTempDir.test.ts
+++ b/packages/library/src/server/applications/neovim/environment/createTempDir.test.ts
@@ -1,6 +1,6 @@
 import fs from "fs"
 import nodePath from "path"
-import { expect, it } from "vitest"
+import { expect, it, vi } from "vitest"
 import type { TestDirsPath } from "./createTempDir.js"
 import { createTempDir } from "./createTempDir.js"
 

--- a/packages/library/src/server/applications/neovim/prepareNewTestDirectory.test.ts
+++ b/packages/library/src/server/applications/neovim/prepareNewTestDirectory.test.ts
@@ -1,5 +1,6 @@
 import { rm } from "fs/promises"
 import path from "path"
+import { assert, describe, expect, it } from "vitest"
 import { prepareNewTestDirectory } from "./prepareNewTestDirectory.js"
 
 describe("prepareNewTestDirectory when the testEnvironmentPath does not exist", () => {

--- a/packages/library/src/server/applications/terminal/runBlockingShellCommand.test.ts
+++ b/packages/library/src/server/applications/terminal/runBlockingShellCommand.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest"
 import { getCwd } from "./runBlockingShellCommand.js"
 
 describe("getCwd", () => {

--- a/packages/library/src/server/blockingCommandInputSchema.test.ts
+++ b/packages/library/src/server/blockingCommandInputSchema.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest"
 import { blockingCommandInputSchema, type BlockingCommandInput } from "./blockingCommandInputSchema.js"
 
 describe("blockingCommandInputSchema", () => {

--- a/packages/library/src/server/cypress-support/createCypressSupportFile.test.ts
+++ b/packages/library/src/server/cypress-support/createCypressSupportFile.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync } from "fs"
 import { mkdir, stat } from "fs/promises"
+import { describe, expect, it, vi } from "vitest"
 import { createCypressSupportFileContents } from "./contents.js"
 import type { CreateCypressSupportFileResult } from "./createCypressSupportFile.js"
 import { createCypressSupportFile } from "./createCypressSupportFile.js"

--- a/packages/library/src/server/updateTestdirectorySchemaFile.test.ts
+++ b/packages/library/src/server/updateTestdirectorySchemaFile.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from "fs"
+import { describe, expect, it, vi } from "vitest"
 import { buildTestDirectorySchema } from "./dirtree/index.js"
 import type { UpdateTestdirectorySchemaFileResult } from "./updateTestdirectorySchemaFile.js"
 import { updateTestdirectorySchemaFile } from "./updateTestdirectorySchemaFile.js"

--- a/packages/library/src/server/utilities/DisposableSingleApplication.test.ts
+++ b/packages/library/src/server/utilities/DisposableSingleApplication.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from "vitest"
 import type { StartableApplication } from "./DisposableSingleApplication.js"
 import { DisposableSingleApplication } from "./DisposableSingleApplication.js"
 import type { ExitInfo } from "./TerminalApplication.js"

--- a/packages/library/src/server/utilities/generator.test.ts
+++ b/packages/library/src/server/utilities/generator.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "stream"
+import { describe, expect, it } from "vitest"
 import { convertEventEmitterToAsyncGenerator } from "./generator.js"
 
 describe("when a listener is attached", () => {

--- a/packages/library/tsconfig.json
+++ b/packages/library/tsconfig.json
@@ -13,7 +13,7 @@
     "allowJs": true,
     "outDir": "dist",
     "lib": ["ES2023", "ESNext.Disposable"],
-    "types": ["node", "vitest/globals"],
+    "types": ["node"],
     "composite": true,
 
     /* Linting */


### PR DESCRIPTION
It had issues when I tried to introduce some built-in cypress assertions to the library.