### PR TITLE
feat: add cypress assertions for checking for text in a color

### DIFF
--- a/packages/integration-tests/cypress/e2e/assertions.cy.ts
+++ b/packages/integration-tests/cypress/e2e/assertions.cy.ts
@@ -1,0 +1,69 @@
+import { flavors } from "@catppuccin/palette"
+
+import {
+  textIsVisibleWithBackgroundColor,
+  textIsVisibleWithColor,
+} from "@tui-sandbox/library/src/client/cypress-assertions"
+import { rgbify } from "../../../library/src/client/color-utilities"
+
+describe("custom assertions bundled with tui-sandbox", () => {
+  it("can use textIsVisibleWithColor", () => {
+    cy.visit("/")
+    cy.startTerminalApplication({
+      commandToRun: ["bash"],
+    }).then(_ => {
+      // wait until text on the start screen is visible
+      cy.contains("myprompt")
+
+      // create some text in various colors
+      cy.typeIntoTerminal('echo -e "\\033[31mred text\\033[0m"{enter}')
+      cy.typeIntoTerminal('echo -e "\\033[32mgreen text\\033[0m"{enter}')
+      cy.typeIntoTerminal('echo -e "\\033[34mblue text\\033[0m"{enter}')
+      cy.typeIntoTerminal('echo -e "\\033[33myellow text\\033[0m"{enter}')
+      cy.typeIntoTerminal('echo -e "\\033[35mpurple text\\033[0m"{enter}')
+
+      textIsVisibleWithColor("red text", rgbify(flavors.macchiato.colors.red.rgb))
+      textIsVisibleWithColor("green text", rgbify(flavors.macchiato.colors.green.rgb))
+      textIsVisibleWithColor("blue text", rgbify(flavors.macchiato.colors.blue.rgb))
+      textIsVisibleWithColor("yellow text", rgbify(flavors.macchiato.colors.yellow.rgb))
+      textIsVisibleWithColor("purple text", rgbify(flavors.macchiato.colors.lavender.rgb))
+
+      // the assertion can match a non-unique string
+      textIsVisibleWithColor("text", rgbify(flavors.macchiato.colors.red.rgb))
+      textIsVisibleWithColor("text", rgbify(flavors.macchiato.colors.green.rgb))
+      textIsVisibleWithColor("text", rgbify(flavors.macchiato.colors.blue.rgb))
+      textIsVisibleWithColor("text", rgbify(flavors.macchiato.colors.yellow.rgb))
+      textIsVisibleWithColor("text", rgbify(flavors.macchiato.colors.lavender.rgb))
+    })
+  })
+
+  it("can use textIsVisibleWithBackgroundColor", () => {
+    cy.visit("/")
+    cy.startTerminalApplication({
+      commandToRun: ["bash"],
+    }).then(_ => {
+      // wait until text on the start screen is visible
+      cy.contains("myprompt")
+
+      // create some text in black foreground and various background colors
+      cy.typeIntoTerminal('echo -e "\\033[30;41mtext on red\\033[0m"{enter}')
+      cy.typeIntoTerminal('echo -e "\\033[30;42mtext on green\\033[0m"{enter}')
+      cy.typeIntoTerminal('echo -e "\\033[30;44mtext on blue\\033[0m"{enter}')
+      cy.typeIntoTerminal('echo -e "\\033[30;43mtext on yellow\\033[0m"{enter}')
+      cy.typeIntoTerminal('echo -e "\\033[30;45mtext on purple\\033[0m"{enter}')
+
+      textIsVisibleWithBackgroundColor("text on red", rgbify(flavors.macchiato.colors.red.rgb))
+      textIsVisibleWithBackgroundColor("text on green", rgbify(flavors.macchiato.colors.green.rgb))
+      textIsVisibleWithBackgroundColor("text on blue", rgbify(flavors.macchiato.colors.blue.rgb))
+      textIsVisibleWithBackgroundColor("text on yellow", rgbify(flavors.macchiato.colors.yellow.rgb))
+      textIsVisibleWithBackgroundColor("text on purple", rgbify(flavors.macchiato.colors.lavender.rgb))
+
+      // the assertion can match a non-unique string
+      textIsVisibleWithBackgroundColor("text", rgbify(flavors.macchiato.colors.red.rgb))
+      textIsVisibleWithBackgroundColor("text", rgbify(flavors.macchiato.colors.green.rgb))
+      textIsVisibleWithBackgroundColor("text", rgbify(flavors.macchiato.colors.blue.rgb))
+      textIsVisibleWithBackgroundColor("text", rgbify(flavors.macchiato.colors.yellow.rgb))
+      textIsVisibleWithBackgroundColor("text", rgbify(flavors.macchiato.colors.lavender.rgb))
+    })
+  })
+})

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -26,6 +26,7 @@
     "@xterm/addon-unicode11": "0.8.0",
     "@xterm/xterm": "5.5.0",
     "cors": "2.8.5",
+    "cypress": "14.5.3",
     "dree": "5.1.5",
     "express": "5.1.0",
     "neovim": "5.3.0",

--- a/packages/library/src/client/cypress-assertions.ts
+++ b/packages/library/src/client/cypress-assertions.ts
@@ -1,0 +1,37 @@
+/// <reference types="cypress" />
+
+/** Problem: cypress provides the `contains` method, but it only checks the
+ * first match on the page.
+ *
+ * Solution: we need to check all elements on the page and filter them
+ * by the text we are looking for. Then we can check if the background
+ * color of the element is the same as the one we are looking for.
+ *
+ * Limitation: text spanning multiple lines will not be detected.
+ */
+export function textIsVisibleWithColor(text: string, color: string): Cypress.Chainable<JQuery> {
+  return cy.get("div.xterm-rows span").and($spans => {
+    const matching = $spans.filter((_, el) => !!el.textContent.includes(text))
+
+    const colors = matching.map((_, el) => {
+      return window.getComputedStyle(el).color
+    })
+
+    expect(JSON.stringify(colors.toArray())).to.contain(color)
+  })
+}
+
+/** Like `textIsVisibleWithColor`, but checks the background color instead
+ * of the text color.
+ */
+export function textIsVisibleWithBackgroundColor(text: string, color: string): Cypress.Chainable<JQuery> {
+  return cy.get("div.xterm-rows span").and($spans => {
+    const matching = $spans.filter((_, el) => !!el.textContent.includes(text))
+
+    const colors = matching.map((_, el) => {
+      return window.getComputedStyle(el).backgroundColor
+    })
+
+    expect(JSON.stringify(colors.toArray())).to.contain(color)
+  })
+}

--- a/packages/library/src/client/index.ts
+++ b/packages/library/src/client/index.ts
@@ -1,5 +1,6 @@
 // This is the public client api. Semantic versioning will be applied to this.
 
 export { rgbify } from "./color-utilities.js"
+export { textIsVisibleWithBackgroundColor, textIsVisibleWithColor } from "./cypress-assertions.js"
 export { NeovimTerminalClient as TerminalClient } from "./neovim-terminal-client.js"
 export { TerminalTerminalClient } from "./terminal-terminal-client.js"

--- a/packages/library/tsconfig.json
+++ b/packages/library/tsconfig.json
@@ -13,7 +13,7 @@
     "allowJs": true,
     "outDir": "dist",
     "lib": ["ES2023", "ESNext.Disposable"],
-    "types": ["node"],
+    "types": ["node", "cypress"],
     "composite": true,
 
     /* Linting */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,8 +117,8 @@ importers:
         specifier: 2.8.5
         version: 2.8.5
       cypress:
-        specifier: ^13 || ^14
-        version: 14.5.0
+        specifier: 14.5.3
+        version: 14.5.3
       dree:
         specifier: 5.1.5
         version: 5.1.5
@@ -188,10 +188,6 @@ packages:
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
-
-  '@cypress/request@3.0.8':
-    resolution: {integrity: sha512-h0NFgh1mJmm1nr4jCwkGHwKneVYKghUyWe6TMNrk0B9zsjAJxpg8C4/+BAcmLgCPa1vj1V8rNUaILl+zYRUWBQ==}
-    engines: {node: '>= 6'}
 
   '@cypress/request@3.0.9':
     resolution: {integrity: sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==}
@@ -1321,10 +1317,6 @@ packages:
     peerDependencies:
       devtools-protocol: '*'
 
-  ci-info@4.2.0:
-    resolution: {integrity: sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==}
-    engines: {node: '>=8'}
-
   ci-info@4.3.0:
     resolution: {integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==}
     engines: {node: '>=8'}
@@ -1453,11 +1445,6 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-
-  cypress@14.5.0:
-    resolution: {integrity: sha512-1HOnKvWep0LkWuFwPeWkZ0TDl7ivi2/Mz+WNU4dfkeLJaFndS3Ow6TXT7YjuTqLFI2peJKzPKljVUFdymI2K5g==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
 
   cypress@14.5.3:
     resolution: {integrity: sha512-syLwKjDeMg77FRRx68bytLdlqHXDT4yBVh0/PPkcgesChYDjUZbwxLqMXuryYKzAyJsPsQHUDW1YU74/IYEUIA==}
@@ -1860,10 +1847,6 @@ packages:
 
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
-
-  form-data@4.0.3:
-    resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
-    engines: {node: '>= 6'}
 
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
@@ -3503,27 +3486,6 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
-  '@cypress/request@3.0.8':
-    dependencies:
-      aws-sign2: 0.7.0
-      aws4: 1.13.2
-      caseless: 0.12.0
-      combined-stream: 1.0.8
-      extend: 3.0.2
-      forever-agent: 0.6.1
-      form-data: 4.0.3
-      http-signature: 1.4.0
-      is-typedarray: 1.0.0
-      isstream: 0.1.2
-      json-stringify-safe: 5.0.1
-      mime-types: 2.1.35
-      performance-now: 2.1.0
-      qs: 6.14.0
-      safe-buffer: 5.2.1
-      tough-cookie: 5.1.2
-      tunnel-agent: 0.6.0
-      uuid: 8.3.2
-
   '@cypress/request@3.0.9':
     dependencies:
       aws-sign2: 0.7.0
@@ -4525,8 +4487,6 @@ snapshots:
       mitt: 3.0.1
       zod: 3.25.76
 
-  ci-info@4.2.0: {}
-
   ci-info@4.3.0: {}
 
   clean-stack@2.2.0: {}
@@ -4647,53 +4607,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  cypress@14.5.0:
-    dependencies:
-      '@cypress/request': 3.0.8
-      '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
-      '@types/sinonjs__fake-timers': 8.1.1
-      '@types/sizzle': 2.3.9
-      arch: 2.2.0
-      blob-util: 2.0.2
-      bluebird: 3.7.2
-      buffer: 5.7.1
-      cachedir: 2.4.0
-      chalk: 4.1.2
-      check-more-types: 2.24.0
-      ci-info: 4.2.0
-      cli-cursor: 3.1.0
-      cli-table3: 0.6.1
-      commander: 6.2.1
-      common-tags: 1.8.2
-      dayjs: 1.11.13
-      debug: 4.4.1(supports-color@8.1.1)
-      enquirer: 2.4.1
-      eventemitter2: 6.4.7
-      execa: 4.1.0
-      executable: 4.1.1
-      extract-zip: 2.0.1(supports-color@8.1.1)
-      figures: 3.2.0
-      fs-extra: 9.1.0
-      getos: 3.2.1
-      hasha: 5.2.2
-      is-installed-globally: 0.4.0
-      lazy-ass: 1.6.0
-      listr2: 3.14.0(enquirer@2.4.1)
-      lodash: 4.17.21
-      log-symbols: 4.1.0
-      minimist: 1.2.8
-      ospath: 1.2.2
-      pretty-bytes: 5.6.0
-      process: 0.11.10
-      proxy-from-env: 1.0.0
-      request-progress: 3.0.0
-      semver: 7.7.2
-      supports-color: 8.1.1
-      tmp: 0.2.3
-      tree-kill: 1.2.2
-      untildify: 4.0.0
-      yauzl: 2.10.0
 
   cypress@14.5.3:
     dependencies:
@@ -5228,14 +5141,6 @@ snapshots:
       signal-exit: 4.1.0
 
   forever-agent@0.6.1: {}
-
-  form-data@4.0.3:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
 
   form-data@4.0.4:
     dependencies:


### PR DESCRIPTION
**Issue:**

It's pretty common to want to see if some text is visible on the screen. Cypress can do this, but there are some limitations:

- Cypress by default only checks for the first match of the text on the page. This makes it hard to check for text that is displayed multiple times on the page
- Cypress does not provide a way to check for text in a specific color or backgroundColor.
- it's complicated to get the instance of the text on the page, because the programmer needs to have knowledge of how xterm.js displays the text.

**Solution:**

Provide two helper functions that can be used:

- `textIsVisibleWithColor(text: string, color: string)`: checks if the text is visible on the page and has the specified color. It checks all elements on the page, not just the first match.
- `textIsVisibleWithBackgroundColor(text: string, color: string)`: the same thing, but for backgroundColor.

Limitation: text spanning multiple lines will not be detected.