### PR TITLE
fix: not being able to import from `@tui-sandbox/library/src/client`

### DIFF
--- a/packages/integration-tests/cypress/e2e/assertions.cy.ts
+++ b/packages/integration-tests/cypress/e2e/assertions.cy.ts
@@ -1,9 +1,6 @@
 import { flavors } from "@catppuccin/palette"
 
-import {
-  textIsVisibleWithBackgroundColor,
-  textIsVisibleWithColor,
-} from "@tui-sandbox/library/src/client/cypress-assertions"
+import { textIsVisibleWithBackgroundColor, textIsVisibleWithColor } from "@tui-sandbox/library/src/client"
 import { rgbify } from "../../../library/src/client/color-utilities"
 
 describe("custom assertions bundled with tui-sandbox", () => {

--- a/packages/integration-tests/cypress/e2e/neovim.cy.ts
+++ b/packages/integration-tests/cypress/e2e/neovim.cy.ts
@@ -1,6 +1,6 @@
 import { flavors } from "@catppuccin/palette"
 import assert from "assert"
-import { rgbify } from "../../../library/src/client/color-utilities"
+import { rgbify } from "../../../library/src/client"
 import type { MyTestDirectoryFile } from "../../MyTestDirectory"
 import type { MyBlockingCommandClientInput } from "../support/tui-sandbox"
 

--- a/packages/library/src/browser/neovim-client.ts
+++ b/packages/library/src/browser/neovim-client.ts
@@ -1,5 +1,5 @@
 import type { Terminal } from "@xterm/xterm"
-import { TerminalClient as NeovimTerminalClient } from "../client/index.js"
+import { NeovimTerminalClient } from "../client/neovim-terminal-client.js"
 import type { TuiTerminalApi } from "../client/startTerminal.js"
 import { TerminalTerminalClient } from "../client/terminal-terminal-client.js"
 import type {

--- a/packages/library/src/client/index.ts
+++ b/packages/library/src/client/index.ts
@@ -2,5 +2,3 @@
 
 export { rgbify } from "./color-utilities.js"
 export { textIsVisibleWithBackgroundColor, textIsVisibleWithColor } from "./cypress-assertions.js"
-export { NeovimTerminalClient as TerminalClient } from "./neovim-terminal-client.js"
-export { TerminalTerminalClient } from "./terminal-terminal-client.js"

--- a/packages/library/src/client/terminal-terminal-client.ts
+++ b/packages/library/src/client/terminal-terminal-client.ts
@@ -7,7 +7,6 @@ import type { AppRouter } from "../server/server.js"
 import type { BlockingShellCommandOutput, TestDirectory } from "../server/types.js"
 import type { TuiTerminalApi } from "./startTerminal.js"
 import { getTabId, startTerminal } from "./startTerminal.js"
-import "./style.css"
 import { supportDA1 } from "./terminal-config.js"
 
 /** Manages the terminal state in the browser as well as the (browser's)


### PR DESCRIPTION
In tests, it was not possible to import from
`@tui-sandbox/library/src/client` because the index.js file referenced css files. These are not understood by the test runner, but they are very important for the actual application so that the styles are included in the build.