### PR TITLE
chore: move vitest workspace config to project config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,7 @@ export default tseslint.config([
       "eslint.config.mjs",
       "packages/integration-tests/cypress.config.ts",
       "packages/integration-tests/test-environment/**/*",
-      "vitest.workspace.js",
+      "vitest.config.js",
       "packages/integration-tests/dist/",
       "packages/library/dist/",
       "packages/library/vite.config.js",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,8 @@
+// https://vitest.dev/guide/projects
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    projects: ["packages/*"],
+  },
+})

--- a/vitest.workspace.js
+++ b/vitest.workspace.js
@@ -1,2 +1,0 @@
-// https://vitest.dev/guide/workspace.html
-export default ["packages/*"]


### PR DESCRIPTION
https://vitest.dev/guide/projects

```sh
❯ pnpm test

> @tui-sandbox/monorepo@1.0.0 test /Users/mikavilpas/git/tui-sandbox
> vitest run

 DEPRECATED  The workspace file is deprecated and will be removed in the next major. Please, use the `test.projects` field in the root config file instead.
```