### PR TITLE
feat: `textIsVisibleWithColor` matches can be hovered in cypress log

### DIFF
--- a/packages/library/src/client/cypress-assertions.ts
+++ b/packages/library/src/client/cypress-assertions.ts
@@ -10,28 +10,26 @@
  * Limitation: text spanning multiple lines will not be detected.
  */
 export function textIsVisibleWithColor(text: string, color: string): Cypress.Chainable<JQuery> {
-  return cy.get("div.xterm-rows span").and($spans => {
-    const matching = $spans.filter((_, el) => el.textContent.includes(text))
-
-    const colors = matching.map((_, el) => {
-      return window.getComputedStyle(el).color
+  return cy
+    .get("div.xterm-rows span")
+    .filter(`:contains(${text})`)
+    .should("exist") // ensures there's at least one match
+    .should($els => {
+      const colors = $els.map((_, el) => window.getComputedStyle(el).color).toArray()
+      expect(colors).to.include(color)
     })
-
-    expect(JSON.stringify(colors.toArray())).to.contain(color)
-  })
 }
 
 /** Like `textIsVisibleWithColor`, but checks the background color instead
  * of the text color.
  */
 export function textIsVisibleWithBackgroundColor(text: string, color: string): Cypress.Chainable<JQuery> {
-  return cy.get("div.xterm-rows span").and($spans => {
-    const matching = $spans.filter((_, el) => el.textContent.includes(text))
-
-    const colors = matching.map((_, el) => {
-      return window.getComputedStyle(el).backgroundColor
+  return cy
+    .get("div.xterm-rows span")
+    .filter(`:contains(${text})`)
+    .should("exist") // ensures there's at least one match
+    .should($els => {
+      const colors = $els.map((_, el) => window.getComputedStyle(el).backgroundColor).toArray()
+      expect(colors).to.include(color)
     })
-
-    expect(JSON.stringify(colors.toArray())).to.contain(color)
-  })
 }


### PR DESCRIPTION
**Issue:**

When matching text in the terminal with `textIsVisibleWithColor` or `textIsVisibleWithBackgroundColor`, the matches are not highlighted in the Cypress log, making it difficult to visually verify which pieces of text were matched.

**Solution:**

Allow the matches to be hovered in the Cypress log. Cypress will then highlight the matches on the page.

<img width="1177" height="536" alt="image" src="https://github.com/user-attachments/assets/44169b87-4c34-438a-b8a4-2af900b4b1d9" />
