### PR TITLE
feat: `tui run` command for running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "pnpm --recursive build",
-    "cy:run": "pnpm --filter=library build && pnpm --filter integration-tests cy:run",
+    "cy:run": "pnpm tui run",
     "dev": "pnpm --filter integration-tests dev",
     "eslint": "eslint --max-warnings=0 .",
     "preinstall": "npx only-allow pnpm",

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -25,6 +25,7 @@
     "@xterm/addon-fit": "0.10.0",
     "@xterm/addon-unicode11": "0.8.0",
     "@xterm/xterm": "5.5.0",
+    "concurrently": "9.2.0",
     "cors": "2.8.5",
     "cypress": "14.5.3",
     "dree": "5.1.5",

--- a/packages/library/src/scripts/commands/commandRunOnce.ts
+++ b/packages/library/src/scripts/commands/commandRunOnce.ts
@@ -1,0 +1,35 @@
+import concurrently from "concurrently"
+import { debuglog } from "util"
+
+const log = debuglog("tui-sandbox.commandRunOnce")
+
+export async function commandRunOnce(): Promise<void> {
+  const job = concurrently(
+    [
+      {
+        name: "server",
+        command: "tui start",
+        prefixColor: "blue",
+      },
+      {
+        name: "cypress",
+        command: `'wait-on --timeout 60000 http-get://127.0.0.1:3000/ping && pnpm exec cypress run --config baseUrl=http://127.0.0.1:3000 --quiet'`,
+        prefixColor: "yellow",
+      },
+    ],
+    {
+      killOthersOn: ["failure", "success"],
+      padPrefix: true, // makes all the prefixes the same length
+      successCondition: "command-cypress", // the test run that determines success/failure
+    }
+  )
+
+  await job.result.then(
+    _ => {
+      log("All commands completed successfully")
+    },
+    (err: unknown) => {
+      log("One or more commands failed. Debug info follows.", err)
+    }
+  )
+}

--- a/packages/library/src/scripts/parseArguments.test.ts
+++ b/packages/library/src/scripts/parseArguments.test.ts
@@ -21,3 +21,8 @@ it(`can parse "start"`, async () => {
   expect(await parseArguments(["start"])).toEqual({ action: "start" })
   expect(await parseArguments(["start", "foo"])).toBeUndefined()
 })
+
+it(`can parse "run"`, async () => {
+  expect(await parseArguments(["run"])).toEqual({ action: "run" })
+  expect(await parseArguments(["run", "foo"])).toBeUndefined()
+})

--- a/packages/library/src/scripts/parseArguments.ts
+++ b/packages/library/src/scripts/parseArguments.ts
@@ -37,9 +37,20 @@ export const parseArguments = async (args: string[]): Promise<ParseArgumentsResu
       }
     }
   }
+
+  {
+    // tui start
+    const schema = z.tuple([z.literal("run")])
+    const result = schema.safeParse(args)
+    if (result.success) {
+      return {
+        action: "run",
+      }
+    }
+  }
 }
 
-export type ParseArgumentsResult = NeovimPrepare | NeovimExec | TuiStart
+export type ParseArgumentsResult = NeovimPrepare | NeovimExec | TuiStart | TuiRunOnce
 
 export type NeovimExec = {
   action: "neovim exec"
@@ -52,4 +63,8 @@ export type NeovimPrepare = {
 
 export type TuiStart = {
   action: "start"
+}
+
+export type TuiRunOnce = {
+  action: "run"
 }

--- a/packages/library/src/scripts/tui.ts
+++ b/packages/library/src/scripts/tui.ts
@@ -1,5 +1,6 @@
 import path from "node:path"
 import type { TestServerConfig } from "../server/index.js"
+import { commandRunOnce } from "./commands/commandRunOnce.js"
 import { commandTuiNeovimExec } from "./commands/commandTuiNeovimExec.js"
 import { commandTuiNeovimPrepare } from "./commands/commandTuiNeovimPrepare.js"
 import { commandTuiStart } from "./commands/commandTuiStart.js"
@@ -38,6 +39,10 @@ switch (command?.action) {
   }
   case "start": {
     await commandTuiStart()
+    break
+  }
+  case "run": {
+    await commandRunOnce()
     break
   }
   default: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       '@xterm/xterm':
         specifier: 5.5.0
         version: 5.5.0
+      concurrently:
+        specifier: 9.2.0
+        version: 9.2.0
       cors:
         specifier: 2.8.5
         version: 2.8.5


### PR DESCRIPTION
**Issue:**

It's complicated to set up an environment for running tests with tui-sandbox.

I want to start reducing the amount of time and knowledge that users need to have to use tui-sandbox.

**Solution:**

As a first step, add a `tui run` command that

- starts the tui-sandbox server
- waits for it to be ready
- runs the tests using Cypress

Now users can depend on this simple command to run tests, instead of having to set up and maintain the different components of the environment themselves.