### PR TITLE
fix: enforce Node.js version >= 24.0.0 or crash at runtime

### DIFF
--- a/packages/library/src/scripts/tui.ts
+++ b/packages/library/src/scripts/tui.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert"
 import path from "node:path"
 import type { TestServerConfig } from "../server/index.js"
 import { commandRun } from "./commands/commandRun.js"
@@ -9,6 +10,15 @@ import { parseArguments } from "./parseArguments.js"
 //
 // This is the main entrypoint to tui-sandbox
 //
+
+const [major] = process.versions.node.split(".").map(Number)
+assert(major)
+assert(!isNaN(major))
+
+if (major < 24) {
+  console.error(`tui-sandbox error: Node.js >= 24.0.0 is required. You are using ${process.version}.`)
+  process.exit(1)
+}
 
 const outputFileName = "MyTestDirectory.ts"
 


### PR DESCRIPTION
Closes https://github.com/mikavilpas/tui-sandbox/issues/563

Example on node 22:

```sh
❯ pnpm tui run

> @tui-sandbox/monorepo@1.0.0 tui /Users/mikavilpas/git/tui-sandbox
> pnpm --filter=library build && pnpm --filter integration-tests exec tui run

packages/library                         |  WARN  Unsupported engine: wanted: {"node":">=24.0.0"} (current: {"node":"v22.18.0","pnpm":"10.14.0"})

> @tui-sandbox/library@11.6.0 build /Users/mikavilpas/git/tui-sandbox/packages/library
> concurrently --names 'vite,tsc' 'vite build' 'tsc' --prefix-colors blue,green

[vite] vite v7.0.6 building for production...
[vite] transforming...
[vite] ✓ 114 modules transformed.
[vite] rendering chunks...
[vite] computing gzip size...
[vite] dist/browser/index.html                                               0.34 kB │ gzip:   0.23 kB
[vite] dist/browser/assets/DejaVuSansMNerdFontMono-Regular-CRJgiq0O.ttf  2,395.67 kB
[vite] dist/browser/assets/index-BYvynUT_.css                                4.48 kB │ gzip:   1.82 kB
[vite] dist/browser/assets/index-BYVmuU8p.js                               403.92 kB │ gzip: 103.39 kB
[vite] ✓ built in 804ms
[vite] vite build exited with code 0
[tsc] tsc exited with code 0
packages/library                         |  WARN  Unsupported engine: wanted: {"node":">=24.0.0"} (current: {"node":"v22.18.0","pnpm":"10.14.0"})
tui-sandbox error: Node.js >= 24.0.0 is required. You are using v22.18.0.
/Users/mikavilpas/git/tui-sandbox/packages/integration-tests:
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command failed with exit code 1: tui run
 ELIFECYCLE  Command failed with exit code 1.
```