### PR TITLE
refactor: use `AsyncDisposableStack.use()` instead of `adopt()`

### DIFF
--- a/packages/library/src/server/applications/neovim/api.ts
+++ b/packages/library/src/server/applications/neovim/api.ts
@@ -83,9 +83,7 @@ export async function initializeStdout(
   const neovim = neovims.get(tabId) ?? new NeovimApplication(testEnvironmentPath)
   if (neovims.get(tabId) === undefined) {
     neovims.set(tabId, neovim)
-    resources.get().adopt(neovim, async n => {
-      await n[Symbol.asyncDispose]()
-    })
+    resources.get().use(neovim)
   }
 
   const stdout = convertEventEmitterToAsyncGenerator(neovim.events, "stdout")

--- a/packages/library/src/server/applications/terminal/api.ts
+++ b/packages/library/src/server/applications/terminal/api.ts
@@ -41,9 +41,7 @@ export async function initializeStdout(
   const app = terminals.get(tabId) ?? new TerminalTestApplication(testEnvironmentPath)
   if (terminals.get(tabId) === undefined) {
     terminals.set(tabId, app)
-    resources.get().adopt(app, async a => {
-      await a[Symbol.asyncDispose]()
-    })
+    resources.get().use(app)
   }
 
   const stdout = convertEventEmitterToAsyncGenerator(app.events, "stdout")


### PR DESCRIPTION
It's the default disposing behavior for resources, so we can simplify the code.