### PR TITLE
fix: not failing test run when tests fail

### DIFF
--- a/packages/library/src/scripts/commands/commandRun.ts
+++ b/packages/library/src/scripts/commands/commandRun.ts
@@ -1,9 +1,17 @@
+import assert from "assert"
+import type { CloseEvent } from "concurrently"
 import concurrently from "concurrently"
+import type { PartialDeep } from "type-fest"
 import { debuglog } from "util"
+import * as z from "zod"
+import type { AllKeys } from "../../server/types.js"
 
 const log = debuglog("tui-sandbox.commandRun")
 
-export async function commandRun(): Promise<void> {
+export type TestResultExitCode = string | number
+
+const cypressName = "cypress"
+export async function commandRun(): Promise<TestResultExitCode> {
   const job = concurrently(
     [
       {
@@ -12,7 +20,7 @@ export async function commandRun(): Promise<void> {
         prefixColor: "blue",
       },
       {
-        name: "cypress",
+        name: cypressName,
         command: `'wait-on --timeout 60000 http-get://127.0.0.1:3000/ping && pnpm exec cypress run --config baseUrl=http://127.0.0.1:3000 --quiet'`,
         prefixColor: "yellow",
       },
@@ -32,4 +40,29 @@ export async function commandRun(): Promise<void> {
       log("One or more commands failed. Debug info follows.", err)
     }
   )
+
+  try {
+    const result = await job.result
+    const cypressCommand = result.find(cmd => cmd.command.name === "cypress")
+    assert(cypressCommand, "Cypress command not found in the result")
+    return cypressCommand.exitCode
+  } catch (e) {
+    // an array of [`CloseEvent`](#CloseEvent), in the order that the commands terminated.
+    // https://github.com/open-cli-tools/concurrently/blob/37212b7d925d8ece22d3afa68a77eef36bb833cc/README.md?plain=1#L125
+    const infos = z
+      .array(
+        z.object({
+          command: z.object({
+            name: z.string(),
+          } satisfies PartialDeep<AllKeys<CloseEvent["command"]>>),
+          exitCode: z.number().or(z.string()),
+        } satisfies PartialDeep<AllKeys<CloseEvent>>)
+      )
+      .parse(e)
+
+    const cypressCommand = infos.find(cmd => cmd.command.name === cypressName)
+    assert(cypressCommand, "Cypress command not found in the result")
+
+    return cypressCommand.exitCode
+  }
 }

--- a/packages/library/src/scripts/tui.ts
+++ b/packages/library/src/scripts/tui.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert"
 import path from "node:path"
 import type { TestServerConfig } from "../server/index.js"
+import type { TestResultExitCode } from "./commands/commandRun.js"
 import { commandRun } from "./commands/commandRun.js"
 import { commandTuiNeovimExec } from "./commands/commandTuiNeovimExec.js"
 import { commandTuiNeovimPrepare } from "./commands/commandTuiNeovimPrepare.js"
@@ -52,8 +53,11 @@ switch (command?.action) {
     break
   }
   case "run": {
-    await commandRun()
-    break
+    const result: TestResultExitCode = await commandRun()
+    // important:
+    //
+    // This is what determines if the test run was successful or not.
+    process.exit(result)
   }
   default: {
     command satisfies undefined


### PR DESCRIPTION
> This fix should be applied as soon as possible.

**Issue:**

The test run is not failed when tests fail if `tui run` is used to run the tests.

**Solution:**

Correctly propagate the exit code from the Cypress command to the exit code of the `tui run` command, fixing the issue.