### PR TITLE
fix: needlessly requiring pnpm in commandRun script

### DIFF
--- a/packages/library/src/scripts/commands/commandRun.ts
+++ b/packages/library/src/scripts/commands/commandRun.ts
@@ -21,7 +21,7 @@ export async function commandRun(): Promise<TestResultExitCode> {
       },
       {
         name: cypressName,
-        command: `'wait-on --timeout 60000 http-get://127.0.0.1:3000/ping && pnpm exec cypress run --config baseUrl=http://127.0.0.1:3000 --quiet'`,
+        command: `'wait-on --timeout 60000 http-get://127.0.0.1:3000/ping && cypress run --config baseUrl=http://127.0.0.1:3000 --quiet'`,
         prefixColor: "yellow",
       },
     ],


### PR DESCRIPTION
This will pave the way for other package managers to use tui-sandbox, but full support is not guaranteed yet.