### PR TITLE
ci: add note about permissions and repo settings for automerge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3
+      - uses: fastify/github-action-merge-dependabot@v3.11.1
         with:
           # https://github.com/fastify/github-action-merge-dependabot?tab=readme-ov-file
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,10 @@ jobs:
     name: Automerge Dependabot PRs
     runs-on: ubuntu-latest
     permissions:
+      # NOTE: no special token needs to be generated if these permissions are
+      # used. However, "Workflow permissions > Allow GitHub Actions to create
+      # and approve pull requests" needs to be enabled
+      # https://github.com/fastify/github-action-merge-dependabot/issues/359
       pull-requests: write
       contents: write
     steps:


### PR DESCRIPTION
# ci: add note about permissions and repo settings for automerge

https://github.com/fastify/github-action-merge-dependabot/issues/359

# ci: use exact version for `fastify/github-action-merge-dependabot`

