### PR TITLE
fix: avoid nodejs error about string exitCode

### DIFF
--- a/packages/library/src/scripts/tui.ts
+++ b/packages/library/src/scripts/tui.ts
@@ -57,7 +57,8 @@ switch (command?.action) {
     // important:
     //
     // This is what determines if the test run was successful or not.
-    process.exit(result)
+    process.exitCode = typeof result === "number" ? result : 1
+    break
   }
   default: {
     command satisfies undefined


### PR DESCRIPTION
**Issue:**

The following message is shown when the test run is exited with SIGINT (Ctrl+C):

```ts
$ [cypress] wait-on --timeout 60000 http-get://127.0.0.1:3000/ping && cypress run --config baseUrl=http://127.0.0.1:3000 --quiet exited with code SIGINT
node:internal/bootstrap/node:119
        validateInteger(value, 'code');
        ^

TypeError [ERR_INVALID_ARG_TYPE]: The "code" argument must be of type number. Received type string ('SIGINT')
    at process.set [as exitCode] (node:internal/bootstrap/node:119:9)
    at file:///Users/mikavilpas/git/tui-sandbox/packages/library/dist/src/scripts/tui.js:50:26 {
  code: 'ERR_INVALID_ARG_TYPE'
}

Node.js v24.6.0
```

**Solution:**

Make sure the exit code is always a number.