### PR TITLE
chore(mise): disable installing node tool in ci

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,8 @@
+[settings]
+disable_tools = ["node"]
+
 [tools]
+
+# small sample application that can be installed with mise and used in the test
+# environment
 cowsay = "latest"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "vitest": "3.2.4",
     "wait-on": "8.0.4"
   },
-  "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b",
+  "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67",
   "pnpm": {
     "onlyBuiltDependencies": [
       "cypress",


### PR DESCRIPTION
# chore: bump pnpm from 10.15.0 to 10.15.1

# chore(mise): disable installing node tool in ci

It's alread installed with actions/setup-node

https://github.com/mikavilpas/tui-sandbox/actions/runs/17442916541/job/49530063143#step:4:62