### PR TITLE
fix(peer-deps): bump wait-on from 9.0.0 to >=9.0.0

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -52,7 +52,7 @@
     "prettier": ">= 3.3.3",
     "type-fest": ">= 4.27.0",
     "typescript": ">= 5.6.3",
-    "wait-on": "9.0.0",
+    "wait-on": ">=9.0.0",
     "zod": ">=4.0.0-0 <5"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,7 +138,7 @@ importers:
         specifier: '>= 5.6.3'
         version: 5.9.2
       wait-on:
-        specifier: 9.0.0
+        specifier: '>=9.0.0'
         version: 9.0.0
       winston:
         specifier: 3.17.0


### PR DESCRIPTION
# fix(peer-deps): bump wait-on from 9.0.0 to >=9.0.0

This resolves a warning during installation:

```sh
$ pnpm i
Scope: all 2 workspace projects
Already up to date
Progress: resolved 650, reused 625, downloaded 0, added 0, done
 WARN  Issues with peer dependencies found
integration-tests
└─┬ @tui-sandbox/library 11.8.1
  └── ✕ unmet peer wait-on@8.0.4: found 9.0.0
Done in 886ms using pnpm v10.17.0
```

https://github.com/jeffbski/wait-on/releases