### PR TITLE
fix: avoid spamming the console with duplicate errors when polling fails

### DIFF
--- a/packages/integration-tests/cypress/e2e/neovim.cy.ts
+++ b/packages/integration-tests/cypress/e2e/neovim.cy.ts
@@ -240,6 +240,23 @@ describe("neovim features", () => {
     })
   })
 
+  it("does not show duplicated errors if the polling fails", () => {
+    cy.visit("/")
+    cy.startNeovim().then(nvim => {
+      Cypress.on("fail", () => {
+        // we expect this error to be able to inspect what the error looks like -
+        // hide it so that the rest of the e2e tests can run
+      })
+
+      // poll for something that will never pass to see what the error messages
+      // look like
+      nvim.waitForLuaCode({
+        luaAssertion: `assert(-1 == 1337)`,
+        timeoutMs: 500,
+      })
+    })
+  })
+
   it("can show messages after a test fails", () => {
     cy.visit("/")
     cy.startNeovim().then(nvim => {

--- a/packages/library/src/server/applications/neovim/api.ts
+++ b/packages/library/src/server/applications/neovim/api.ts
@@ -198,7 +198,7 @@ export async function waitForLuaCode(
     running = false
   })
 
-  const failureMessages: string[] = []
+  const failureMessages = new Set<string>()
   const reportFailure = () => {
     console.warn(`Polling Lua code: '${options.luaAssertion}' failed. Failure messages:`, failureMessages)
   }
@@ -217,7 +217,7 @@ export async function waitForLuaCode(
 
       return { value }
     } catch (e) {
-      failureMessages.push(`Caught error in iteration ${iteration}: ${String(e)}`)
+      failureMessages.add(String(e))
       await timeout(100)
     }
   }


### PR DESCRIPTION
**Issue:**

When polling Lua code in Neovim using `waitForLuaCode()`, if the code consistently fails (e.g., an assertion that is always false), the console gets flooded with duplicate error messages.

```rust
Polling Lua code: 'assert(-1 == 1337)' failed. Failure messages: [
  'Caught error in iteration 1: Error: nvim_execute_lua: Lua: [string "<nvim>"]:1: assertion failed!\n' +
    'stack traceback:\n' +
    "\t[C]: in function 'assert'\n" +
    '\t[string "<nvim>"]:1: in main chunk',
  'Caught error in iteration 2: Error: nvim_execute_lua: Lua: [string "<nvim>"]:1: assertion failed!\n' +
    'stack traceback:\n' +
    "\t[C]: in function 'assert'\n" +
    '\t[string "<nvim>"]:1: in main chunk',
  'Caught error in iteration 3: Error: nvim_execute_lua: Lua: [string "<nvim>"]:1: assertion failed!\n' +
    'stack traceback:\n' +
    "\t[C]: in function 'assert'\n" +
    '\t[string "<nvim>"]:1: in main chunk',
  'Caught error in iteration 4: Error: nvim_execute_lua: Lua: [string "<nvim>"]:1: assertion failed!\n' +
    'stack traceback:\n' +
    "\t[C]: in function 'assert'\n" +
    '\t[string "<nvim>"]:1: in main chunk'
]
```

This makes it difficult to get a clear overview of the errors.

**Solution:**

Remove the "in iteration N" part of the error messages to make the duplicates stand out. Then deduplicate the error messages by using a `Set` instead of an array to store them.

Now only unique error messages are logged:

```rust
Polling Lua code: 'assert(-1 == 1337)' failed. Failure messages: Set(1) {
  'Error: nvim_execute_lua: Lua: [string "<nvim>"]:1: assertion failed!\n' +
    'stack traceback:\n' +
    "\t[C]: in function 'assert'\n" +
    '\t[string "<nvim>"]:1: in main chunk'
}
```