### PR TITLE
chore(renovate): enable commit body table

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "automerge": true,
+  "commitBodyTable": true,
   "extends": ["config:best-practices", "group:allNonMajor"]
 }


### PR DESCRIPTION
> If enabled, append a table in the commit message body describing all
> updates in the commit.
>
> https://docs.renovatebot.com/configuration-options/#commitbodytable

Random example from github:
https://github.com/kuberhealthy/kuberhealthy/commit/cd82eaaa057d02f1e2358b89738a095912eb8cb6