### PR TITLE
feat(zerobox): terminal tests can opt in to zerobox for whiteboxing

### DIFF
--- a/packages/integration-tests/cypress/e2e/terminal.cy.ts
+++ b/packages/integration-tests/cypress/e2e/terminal.cy.ts
@@ -25,11 +25,31 @@ describe("terminal snapshot file", () => {
     cy.readFile(snapshotPath).then((yaml: string) => {
       expect(yaml).to.include("writes a snapshot after a passing test")
       expect(yaml).to.include("testFile:")
-      expect(yaml).to.include("terminal.cy.ts")
       expect(yaml).to.include("testState: passed")
       expect(yaml).to.include("myprompt")
       expect(yaml).to.include("error: null")
       expect(yaml).to.include("terminalContent: |")
+    })
+  })
+})
+
+describe("zerobox integration", () => {
+  it("prevents writing to directories outside the test environment", () => {
+    cy.visit("/")
+    cy.startTerminalApplication({
+      commandToRun: ["bash"],
+    }).then(() => {
+      cy.contains("myprompt")
+
+      // writing inside the test directory should succeed — the file is
+      // created and ls confirms it exists
+      cy.typeIntoTerminal("touch ./zerobox-allowed-file{enter}")
+      cy.typeIntoTerminal("ls ./zerobox-allowed-file{enter}")
+      cy.contains("zerobox-allowed-file")
+
+      // writing outside the test directory should be blocked by zerobox
+      cy.typeIntoTerminal("touch /tmp/zerobox-spike-test-file{enter}")
+      cy.contains("Operation not permitted")
     })
   })
 })
@@ -83,7 +103,7 @@ describe("TerminalTestApplication features", () => {
     }).then(() => {
       // the error message is not very informative, but the tester should be
       // able to see more details in the test output
-      cy.contains(/Child process \d+? \(thisdoesnotexist\) exited with code 1/)
+      cy.contains(/Child process \d+? .+? exited with code \d+/)
     })
   })
 

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@catppuccin/palette": "1.8.0",
     "@tui-sandbox/library": "workspace:*",
+    "zerobox": "0.1.11",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/packages/integration-tests/tui-sandbox.config.ts
+++ b/packages/integration-tests/tui-sandbox.config.ts
@@ -3,3 +3,4 @@ import type { TestServerConfig } from "@tui-sandbox/library/dist/src/server/inde
 
 export const config: TestServerConfig = createDefaultConfig(process.cwd(), process.env)
 config.integrations.neovim.NVIM_APPNAMEs = ["nvim", "nvim_alt"]
+config.integrations.UNSTABLE_zerobox.enabled = true

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -63,6 +63,7 @@
     "prettier": "3.8.1",
     "tsx": "4.21.0",
     "winston": "3.19.0",
+    "zerobox": "0.1.9",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -63,7 +63,7 @@
     "prettier": "3.8.1",
     "tsx": "4.21.0",
     "winston": "3.19.0",
-    "zerobox": "0.1.9",
+    "zerobox": "0.1.11",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/packages/library/src/scripts/resolveConfig.test.ts
+++ b/packages/library/src/scripts/resolveConfig.test.ts
@@ -24,7 +24,10 @@ it("loads a custom configuration file if it exists", async () => {
       outputFilePath: "./output.ts",
       latestSymlinkName: "latest",
     },
-    integrations: { neovim: { NVIM_APPNAMEs: ["nvim", "nvim_2"] } },
+    integrations: {
+      neovim: { NVIM_APPNAMEs: ["nvim", "nvim_2"] },
+      UNSTABLE_zerobox: { enabled: false },
+    },
     port: 12345,
   }
   {

--- a/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
+++ b/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
@@ -4,6 +4,7 @@ import EventEmitter from "events"
 import { join } from "path"
 import { debuglog } from "util"
 import type { TestDirectory, TestEnvironmentCommonEnvironmentVariables } from "../../types.js"
+import type { ZeroboxIntegrationConfig } from "../../updateTestdirectorySchemaFile.js"
 import { DisposableSingleApplication } from "../../utilities/DisposableSingleApplication.js"
 import { TerminalApplication } from "../../utilities/TerminalApplication.js"
 import type { StdoutOrStderrMessage, TerminalDimensions } from "../neovim/NeovimApplication.js"
@@ -32,7 +33,8 @@ export default class TerminalTestApplication implements AsyncDisposable {
   public async startNextAndKillCurrent(
     testDirectory: TestDirectory,
     startArgs: StartTerminalGenericArguments,
-    terminalDimensions: TerminalDimensions
+    terminalDimensions: TerminalDimensions,
+    zeroboxConfig?: ZeroboxIntegrationConfig
   ): Promise<void> {
     await this[Symbol.asyncDispose]()
     assert(
@@ -40,10 +42,24 @@ export default class TerminalTestApplication implements AsyncDisposable {
       "TerminalTestApplication state should be undefined after disposing so that no previous state is reused."
     )
 
-    const command = startArgs.commandToRun[0]
+    let command = startArgs.commandToRun[0]
     assert(command, "No command to run was provided.")
-    // TODO could check if the command is executable
-    const terminalArguments = startArgs.commandToRun.slice(1)
+    let terminalArguments = startArgs.commandToRun.slice(1)
+
+    if (zeroboxConfig?.enabled) {
+      const { resolveZeroboxBinary } = await import("./resolveZeroboxBinary.js")
+      const zeroboxBin = resolveZeroboxBinary()
+      terminalArguments = [
+        `--allow-write=${testDirectory.rootPathAbsolute}`,
+        "--allow-write=/dev/tty",
+        "--allow-env",
+        "--",
+        command,
+        ...terminalArguments,
+      ]
+      command = zeroboxBin
+      log(`🔒 zerobox enabled: wrapping command with ${zeroboxBin}`)
+    }
 
     const stdout = this.events
 

--- a/packages/library/src/server/applications/terminal/api.ts
+++ b/packages/library/src/server/applications/terminal/api.ts
@@ -29,7 +29,8 @@ export async function start(
       commandToRun: startTerminalArguments.commandToRun,
       additionalEnvironmentVariables: startTerminalArguments.additionalEnvironmentVariables,
     },
-    startTerminalArguments.terminalDimensions
+    startTerminalArguments.terminalDimensions,
+    config.integrations.UNSTABLE_zerobox
   )
 
   return testDirectory

--- a/packages/library/src/server/applications/terminal/resolveZeroboxBinary.ts
+++ b/packages/library/src/server/applications/terminal/resolveZeroboxBinary.ts
@@ -1,0 +1,35 @@
+import { existsSync } from "fs"
+import { createRequire } from "module"
+import { dirname, join } from "path"
+
+/**
+ * Resolve the native zerobox binary path. Prefers the platform-specific
+ * native binary over the shell shim so that node-pty talks directly to
+ * the Rust process (better PTY passthrough).
+ */
+export const resolveZeroboxBinary = (): string => {
+  const require = createRequire(import.meta.url)
+
+  // Try platform-specific native binary first
+  const platform = process.platform
+  const arch = process.arch
+  const pkgName = `@zerobox/cli-${platform}-${arch}`
+
+  try {
+    const pkgJson = require.resolve(`${pkgName}/package.json`)
+    const nativeBin = join(dirname(pkgJson), "zerobox")
+    if (existsSync(nativeBin)) {
+      return nativeBin
+    }
+  } catch {
+    // Package not installed, fall through
+  }
+
+  // Fallback to the shell shim
+  const shimPath = join(import.meta.dirname, "..", "..", "..", "..", "..", "node_modules", ".bin", "zerobox")
+  if (existsSync(shimPath)) {
+    return shimPath
+  }
+
+  throw new Error("Could not find zerobox binary. Install it with: pnpm add zerobox")
+}

--- a/packages/library/src/server/config.ts
+++ b/packages/library/src/server/config.ts
@@ -13,6 +13,9 @@ export const createDefaultConfig = (cwd: string, environment: NodeJS.ProcessEnv)
       neovim: {
         NVIM_APPNAMEs: ["nvim"],
       },
+      UNSTABLE_zerobox: {
+        enabled: false,
+      },
     },
   }
 }

--- a/packages/library/src/server/dirtree/index.test.ts
+++ b/packages/library/src/server/dirtree/index.test.ts
@@ -27,6 +27,7 @@ describe("dirtree", () => {
         neovim: {
           NVIM_APPNAMEs: ["nvim" satisfies NeovimIntegrationDefaultAppName, "nvim_alt"],
         },
+        UNSTABLE_zerobox: { enabled: false },
       },
     }
     const result = await buildSchemaForDirectoryTree(output.get(), "MyDirectoryTree", config)
@@ -310,6 +311,7 @@ describe("dirtree", () => {
           neovim: {
             NVIM_APPNAMEs: ["nvim" satisfies NeovimIntegrationDefaultAppName, "nvim_alt"],
           },
+          UNSTABLE_zerobox: { enabled: false },
         },
       }
       const tinytree = getDirectoryTree(smallDirectory)

--- a/packages/library/src/server/updateTestdirectorySchemaFile.ts
+++ b/packages/library/src/server/updateTestdirectorySchemaFile.ts
@@ -33,6 +33,14 @@ const neovimIntegration = z.strictObject({
 
 export type NeovimIntegrationConfig = z.output<typeof neovimIntegration>
 
+const zeroboxIntegration = z
+  .strictObject({
+    enabled: z.boolean().default(false),
+  })
+  .default({ enabled: false })
+
+export type ZeroboxIntegrationConfig = z.output<typeof zeroboxIntegration>
+
 export const testServerConfigSchema = z.strictObject({
   directories: z.object({
     testEnvironmentPath: z.string(),
@@ -42,6 +50,7 @@ export const testServerConfigSchema = z.strictObject({
   port: z.number().int().min(1).max(65535),
   integrations: z.strictObject({
     neovim: neovimIntegration,
+    UNSTABLE_zerobox: zeroboxIntegration,
   }),
 })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       winston:
         specifier: 3.19.0
         version: 3.19.0
+      zerobox:
+        specifier: 0.1.9
+        version: 0.1.9
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -1091,6 +1094,46 @@ packages:
 
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
+
+  '@zerobox/cli-darwin-arm64@0.1.9':
+    resolution: {integrity: sha512-W95tGIfLWDMVWNIkkgK4lnhD8HIzmatxw/m00CsugQwHfdPranOC1RhK6LQeQbTWCHf5n23vCcLLbdFKpaM2yQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@zerobox/cli-darwin-x64@0.1.9':
+    resolution: {integrity: sha512-t6dUc8RbJJ6BVjeYo+/LRh+dwDpr8isL8TS2UI1SIsWOBsVIQZeFYXRcXlgfEQhNj6wUYHKyS/z8RiiRD8RJ2Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@zerobox/cli-linux-arm64-musl@0.1.9':
+    resolution: {integrity: sha512-g7UJK+MxeljOwYEeH4FlNTDSa4mSe2HGeRuSbIMhD90e3t8lLjRDR6/d185B+T2nNIgDOolvYuOpyDYhoSxRjQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@zerobox/cli-linux-arm64@0.1.9':
+    resolution: {integrity: sha512-ITfyA53ykHFcodEar/Fi1K1Duszc5RICmD5VfMBMtryTedfW+yMb2Bqkyy1V5I5bBABBo9pI6KNl/tagfCZ5bA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@zerobox/cli-linux-x64-musl@0.1.9':
+    resolution: {integrity: sha512-y7r6iSqUGFDqySE8InQ8RmG/IUsCYzgLovwPoNHkO4k3CRgDkfIVSdlxAZmErLbUNRXWVHCSpHeto4FlNWEj/g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@zerobox/cli-linux-x64@0.1.9':
+    resolution: {integrity: sha512-QyCj41vsy3Bbo8Wfy3voYoEmVyNWWjJNNg1DTo/sDosD+9kZPyRpDs6hD/MI/irH+CwWljIYCxEPKNM3VEfoDg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
@@ -3562,6 +3605,11 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
+  zerobox@0.1.9:
+    resolution: {integrity: sha512-GHMWITdU3ERqNp4k+lu6puG96cMo/TA3snIjwKTjJIVQ8+M1k9w9t9MdWBj8ZcSHZtWrksfemCZINR+ijISnRA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -4360,6 +4408,24 @@ snapshots:
   '@xterm/addon-unicode11@0.9.0': {}
 
   '@xterm/xterm@6.0.0': {}
+
+  '@zerobox/cli-darwin-arm64@0.1.9':
+    optional: true
+
+  '@zerobox/cli-darwin-x64@0.1.9':
+    optional: true
+
+  '@zerobox/cli-linux-arm64-musl@0.1.9':
+    optional: true
+
+  '@zerobox/cli-linux-arm64@0.1.9':
+    optional: true
+
+  '@zerobox/cli-linux-x64-musl@0.1.9':
+    optional: true
+
+  '@zerobox/cli-linux-x64@0.1.9':
+    optional: true
 
   abbrev@4.0.0:
     optional: true
@@ -7208,6 +7274,15 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
+
+  zerobox@0.1.9:
+    optionalDependencies:
+      '@zerobox/cli-darwin-arm64': 0.1.9
+      '@zerobox/cli-darwin-x64': 0.1.9
+      '@zerobox/cli-linux-arm64': 0.1.9
+      '@zerobox/cli-linux-arm64-musl': 0.1.9
+      '@zerobox/cli-linux-x64': 0.1.9
+      '@zerobox/cli-linux-x64-musl': 0.1.9
 
   zod@3.25.76: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       '@tui-sandbox/library':
         specifier: workspace:*
         version: link:../library
+      zerobox:
+        specifier: 0.1.11
+        version: 0.1.11
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -153,8 +156,8 @@ importers:
         specifier: 3.19.0
         version: 3.19.0
       zerobox:
-        specifier: 0.1.9
-        version: 0.1.9
+        specifier: 0.1.11
+        version: 0.1.11
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -1095,41 +1098,41 @@ packages:
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
-  '@zerobox/cli-darwin-arm64@0.1.9':
-    resolution: {integrity: sha512-W95tGIfLWDMVWNIkkgK4lnhD8HIzmatxw/m00CsugQwHfdPranOC1RhK6LQeQbTWCHf5n23vCcLLbdFKpaM2yQ==}
+  '@zerobox/cli-darwin-arm64@0.1.11':
+    resolution: {integrity: sha512-9goqeHGttBP5Sa+Z/hSZct8aiId+OwwRL5XBHWW0elH7tw+pTUKKBt4fqilu6HEHhY8OmWvYyKRU8/3k68HaoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@zerobox/cli-darwin-x64@0.1.9':
-    resolution: {integrity: sha512-t6dUc8RbJJ6BVjeYo+/LRh+dwDpr8isL8TS2UI1SIsWOBsVIQZeFYXRcXlgfEQhNj6wUYHKyS/z8RiiRD8RJ2Q==}
+  '@zerobox/cli-darwin-x64@0.1.11':
+    resolution: {integrity: sha512-tRWP3F/GPvfX4Ki+oVGWZNUX92j99S1SQnNY9fQcm4pBIWZh/W+Gk/HKPzp5AZvH4RTi5PmrH2nKTIFCU5vgmQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@zerobox/cli-linux-arm64-musl@0.1.9':
-    resolution: {integrity: sha512-g7UJK+MxeljOwYEeH4FlNTDSa4mSe2HGeRuSbIMhD90e3t8lLjRDR6/d185B+T2nNIgDOolvYuOpyDYhoSxRjQ==}
+  '@zerobox/cli-linux-arm64-musl@0.1.11':
+    resolution: {integrity: sha512-G4HtluBOpF7dy16LBAgoz7sInLcwmefsgwRs9w+XHhLEQSdWNYlslAvsgSpxhm+FWzZ8grzQkOrmPoLa1cv1lQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@zerobox/cli-linux-arm64@0.1.9':
-    resolution: {integrity: sha512-ITfyA53ykHFcodEar/Fi1K1Duszc5RICmD5VfMBMtryTedfW+yMb2Bqkyy1V5I5bBABBo9pI6KNl/tagfCZ5bA==}
+  '@zerobox/cli-linux-arm64@0.1.11':
+    resolution: {integrity: sha512-LBNjwZlojkuS+OzQzsfrFZyvVArwQiN+kKHTlaHLr74aOGtPpQ6QnzxE08JYCPoUIeMYfRsrjKq5YFqve32ldQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@zerobox/cli-linux-x64-musl@0.1.9':
-    resolution: {integrity: sha512-y7r6iSqUGFDqySE8InQ8RmG/IUsCYzgLovwPoNHkO4k3CRgDkfIVSdlxAZmErLbUNRXWVHCSpHeto4FlNWEj/g==}
+  '@zerobox/cli-linux-x64-musl@0.1.11':
+    resolution: {integrity: sha512-KqFFywDoXwaEJZ+39U2mvFmUYiTTCFacQvsJwSmKgMV3n4gl7+mmJ1kAvBLwf5+gst+QqPfT37AoBrurasm4yg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@zerobox/cli-linux-x64@0.1.9':
-    resolution: {integrity: sha512-QyCj41vsy3Bbo8Wfy3voYoEmVyNWWjJNNg1DTo/sDosD+9kZPyRpDs6hD/MI/irH+CwWljIYCxEPKNM3VEfoDg==}
+  '@zerobox/cli-linux-x64@0.1.11':
+    resolution: {integrity: sha512-vCNZeo7iHCs2deKX7Rl5WaIoy67VDVs1+pD/mgcj/s9kOw+JLRm2jj0S5oRaCx0yC9nu7u84dBWbiplBCkpOrw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -3605,8 +3608,8 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
-  zerobox@0.1.9:
-    resolution: {integrity: sha512-GHMWITdU3ERqNp4k+lu6puG96cMo/TA3snIjwKTjJIVQ8+M1k9w9t9MdWBj8ZcSHZtWrksfemCZINR+ijISnRA==}
+  zerobox@0.1.11:
+    resolution: {integrity: sha512-XgKO0BsrfNvKjD9YLRVPUDBaTPT3S/gDypVGCkd/cmLIGJNUx8wrEcZhpaAAySElHllUzma41b9BfGIKkSGajg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4409,22 +4412,22 @@ snapshots:
 
   '@xterm/xterm@6.0.0': {}
 
-  '@zerobox/cli-darwin-arm64@0.1.9':
+  '@zerobox/cli-darwin-arm64@0.1.11':
     optional: true
 
-  '@zerobox/cli-darwin-x64@0.1.9':
+  '@zerobox/cli-darwin-x64@0.1.11':
     optional: true
 
-  '@zerobox/cli-linux-arm64-musl@0.1.9':
+  '@zerobox/cli-linux-arm64-musl@0.1.11':
     optional: true
 
-  '@zerobox/cli-linux-arm64@0.1.9':
+  '@zerobox/cli-linux-arm64@0.1.11':
     optional: true
 
-  '@zerobox/cli-linux-x64-musl@0.1.9':
+  '@zerobox/cli-linux-x64-musl@0.1.11':
     optional: true
 
-  '@zerobox/cli-linux-x64@0.1.9':
+  '@zerobox/cli-linux-x64@0.1.11':
     optional: true
 
   abbrev@4.0.0:
@@ -7275,14 +7278,14 @@ snapshots:
 
   yoctocolors@2.1.2: {}
 
-  zerobox@0.1.9:
+  zerobox@0.1.11:
     optionalDependencies:
-      '@zerobox/cli-darwin-arm64': 0.1.9
-      '@zerobox/cli-darwin-x64': 0.1.9
-      '@zerobox/cli-linux-arm64': 0.1.9
-      '@zerobox/cli-linux-arm64-musl': 0.1.9
-      '@zerobox/cli-linux-x64': 0.1.9
-      '@zerobox/cli-linux-x64-musl': 0.1.9
+      '@zerobox/cli-darwin-arm64': 0.1.11
+      '@zerobox/cli-darwin-x64': 0.1.11
+      '@zerobox/cli-linux-arm64': 0.1.11
+      '@zerobox/cli-linux-arm64-musl': 0.1.11
+      '@zerobox/cli-linux-x64': 0.1.11
+      '@zerobox/cli-linux-x64-musl': 0.1.11
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
# chore: bump zerobox from 0.1.9 to 0.1.11

# feat(zerobox): terminal tests can opt in to zerobox for whiteboxing

This is alpha quality at this point! More documentation may follow if the approach looks promising after some further experimentation.

---

# Pull request stack

- 👉🏻 **[#1075](https://github.com/mikavilpas/tui-sandbox/pull/1075)** | feat(zerobox): terminal tests can opt in to zerobox for whiteboxing 👈🏻
  - [#1076](https://github.com/mikavilpas/tui-sandbox/pull/1076) | refactor(zerobox): use builtin zerobox `resolveBinary()`
    - [#1077](https://github.com/mikavilpas/tui-sandbox/pull/1077) | fix(zerobox): allow /dev/tty access on macOS only, linux seems broken