### PR TITLE
feat(zerobox): add nvim test support using zerobox on osx

### DIFF
--- a/packages/library/src/server/applications/neovim/NeovimApplication.ts
+++ b/packages/library/src/server/applications/neovim/NeovimApplication.ts
@@ -6,6 +6,7 @@ import type { NeovimClient as NeovimApiClient } from "neovim"
 import { tmpdir } from "os"
 import path, { join } from "path"
 import { debuglog } from "util"
+import type { SandboxOptions } from "zerobox"
 import type { TestDirectory, TestEnvironmentCommonEnvironmentVariables } from "../../types.js"
 import { DisposableSingleApplication } from "../../utilities/DisposableSingleApplication.js"
 import type { Lazy } from "../../utilities/Lazy.js"
@@ -111,7 +112,8 @@ export class NeovimApplication implements AsyncDisposable {
   public async startNextAndKillCurrent(
     testDirectory: TestDirectory,
     startArgs: StartNeovimGenericArguments,
-    terminalDimensions: TerminalDimensions
+    terminalDimensions: TerminalDimensions,
+    zerobox?: SandboxOptions
   ): Promise<void> {
     await this[Symbol.asyncDispose]()
     assert(
@@ -174,6 +176,7 @@ export class NeovimApplication implements AsyncDisposable {
         cwd: this.testEnvironmentPath,
         env,
         dimensions: terminalDimensions,
+        zerobox,
 
         onStdoutOrStderr(data) {
           data satisfies string

--- a/packages/library/src/server/applications/neovim/api.ts
+++ b/packages/library/src/server/applications/neovim/api.ts
@@ -2,6 +2,7 @@ import assert from "assert"
 import { access } from "fs/promises"
 import path from "path"
 import { debuglog } from "util"
+import type { SandboxOptions } from "zerobox"
 import type { BlockingCommandInput } from "../../blockingCommandInputSchema.js"
 import type {
   BlockingShellCommandOutput,
@@ -104,7 +105,25 @@ export async function start(
   assert(neovim, `Neovim instance not found for client id ${tabId.tabId}`)
 
   const testDirectory = await prepareNewTestDirectory(config)
-  await neovim.startNextAndKillCurrent(testDirectory, options, terminalDimensions)
+
+  const zeroboxConfig = config.integrations.UNSTABLE_zerobox
+  let zerobox: SandboxOptions | undefined
+  if (zeroboxConfig.enabled) {
+    const { tmpdir } = await import("os")
+    zerobox = {
+      allowWrite: [testDirectory.rootPathAbsolute, tmpdir()],
+      allowEnv: true,
+      // Neovim uses a unix domain socket for --listen (RPC API).
+      // macOS sandbox-exec treats socket creation as a network operation,
+      // so we need to allow network access. Ideally we'd restrict this to
+      // unix sockets only (zerobox has internal support for this via
+      // UnixDomainSocketPolicy), but the CLI/SDK don't expose it yet.
+      // TODO: tighten to unix sockets only when zerobox exposes the option
+      allowNet: true,
+    }
+  }
+
+  await neovim.startNextAndKillCurrent(testDirectory, options, terminalDimensions, zerobox)
 
   return testDirectory
 }

--- a/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
+++ b/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
@@ -3,8 +3,8 @@ import { exec } from "child_process"
 import EventEmitter from "events"
 import { join } from "path"
 import { debuglog } from "util"
+import type { SandboxOptions } from "zerobox"
 import type { TestDirectory, TestEnvironmentCommonEnvironmentVariables } from "../../types.js"
-import type { ZeroboxIntegrationConfig } from "../../updateTestdirectorySchemaFile.js"
 import { DisposableSingleApplication } from "../../utilities/DisposableSingleApplication.js"
 import { TerminalApplication } from "../../utilities/TerminalApplication.js"
 import type { StdoutOrStderrMessage, TerminalDimensions } from "../neovim/NeovimApplication.js"
@@ -34,7 +34,7 @@ export default class TerminalTestApplication implements AsyncDisposable {
     testDirectory: TestDirectory,
     startArgs: StartTerminalGenericArguments,
     terminalDimensions: TerminalDimensions,
-    zeroboxConfig?: ZeroboxIntegrationConfig
+    zerobox?: SandboxOptions
   ): Promise<void> {
     await this[Symbol.asyncDispose]()
     assert(
@@ -42,21 +42,9 @@ export default class TerminalTestApplication implements AsyncDisposable {
       "TerminalTestApplication state should be undefined after disposing so that no previous state is reused."
     )
 
-    let command = startArgs.commandToRun[0]
+    const command = startArgs.commandToRun[0]
     assert(command, "No command to run was provided.")
-    let terminalArguments = startArgs.commandToRun.slice(1)
-
-    if (zeroboxConfig?.enabled) {
-      const { resolveBinary, buildFlags } = await import("zerobox")
-      const zeroboxBin = resolveBinary()
-      const flags = buildFlags({
-        allowWrite: [testDirectory.rootPathAbsolute, "/dev/tty"],
-        allowEnv: true,
-      })
-      terminalArguments = [...flags, "--", command, ...terminalArguments]
-      command = zeroboxBin
-      log(`🔒 zerobox enabled: wrapping command with ${zeroboxBin}`)
-    }
+    const terminalArguments = startArgs.commandToRun.slice(1)
 
     const stdout = this.events
 
@@ -69,6 +57,7 @@ export default class TerminalTestApplication implements AsyncDisposable {
         cwd: testDirectory.rootPathAbsolute,
         env,
         dimensions: terminalDimensions,
+        zerobox,
 
         onStdoutOrStderr(data) {
           data satisfies string

--- a/packages/library/src/server/applications/terminal/api.ts
+++ b/packages/library/src/server/applications/terminal/api.ts
@@ -1,4 +1,5 @@
 import assert from "assert"
+import type { SandboxOptions } from "zerobox"
 import type { BlockingCommandInput } from "../../blockingCommandInputSchema.js"
 import type { BlockingShellCommandOutput, TestDirectory } from "../../types.js"
 import type { TestServerConfig } from "../../updateTestdirectorySchemaFile.js"
@@ -23,6 +24,20 @@ export async function start(
   const app = terminals.get(tabId.tabId)
   assert(app, `Terminal with tabId ${tabId.tabId} not found.`)
   const testDirectory = await prepareNewTestDirectory(config)
+  const zeroboxConfig = config.integrations.UNSTABLE_zerobox
+  let zerobox: SandboxOptions | undefined
+  if (zeroboxConfig.enabled) {
+    zerobox = {
+      allowWrite: [testDirectory.rootPathAbsolute],
+      allowEnv: true,
+    }
+    // macOS blocks /dev/tty access inside the sandbox, so we need to
+    // explicitly allow it. Linux doesn't need this.
+    if (process.platform === "darwin") {
+      zerobox.allowWrite?.push("/dev/tty")
+    }
+  }
+
   await app.startNextAndKillCurrent(
     testDirectory,
     {
@@ -30,7 +45,7 @@ export async function start(
       additionalEnvironmentVariables: startTerminalArguments.additionalEnvironmentVariables,
     },
     startTerminalArguments.terminalDimensions,
-    config.integrations.UNSTABLE_zerobox
+    zerobox
   )
 
   return testDirectory

--- a/packages/library/src/server/utilities/TerminalApplication.ts
+++ b/packages/library/src/server/utilities/TerminalApplication.ts
@@ -5,6 +5,7 @@ import type { ITerminalDimensions } from "@xterm/addon-fit"
 import type { IPty } from "node-pty"
 import pty from "node-pty"
 import { debuglog } from "util"
+import type { SandboxOptions } from "zerobox"
 import type { StartableApplication } from "./DisposableSingleApplication.js"
 
 const log = debuglog("tui-sandbox.TerminalApplication")
@@ -43,13 +44,14 @@ export class TerminalApplication implements StartableApplication {
   }
 
   /** @constructor Start a new terminal application. */
-  public static start({
+  public static async start({
     onStdoutOrStderr,
     command,
     args,
     cwd,
     env,
     dimensions,
+    zerobox: zeroboxOptions,
   }: {
     onStdoutOrStderr: (data: string) => void
     command: string
@@ -57,7 +59,18 @@ export class TerminalApplication implements StartableApplication {
     cwd: string
     env?: NodeJS.ProcessEnv
     dimensions: ITerminalDimensions
-  }): TerminalApplication {
+    /** When provided, the command is wrapped inside a zerobox sandbox. */
+    zerobox?: SandboxOptions
+  }): Promise<TerminalApplication> {
+    if (zeroboxOptions) {
+      const { resolveBinary, buildFlags } = await import("zerobox")
+      const zeroboxBin = resolveBinary()
+      const flags = buildFlags(zeroboxOptions)
+      args = [...flags, "--", command, ...args]
+      command = zeroboxBin
+      log(`🔒 zerobox enabled: wrapping command with ${zeroboxBin}`)
+    }
+
     log(`Starting '${command}' with args '${args.join(" ")}' in cwd '${cwd}'`)
 
     const ptyProcess = pty.spawn(command, args, {


### PR DESCRIPTION
# feat(zerobox): add nvim test support using zerobox on osx

---

# Pull request stack

- [#1075](https://github.com/mikavilpas/tui-sandbox/pull/1075) | feat(zerobox): terminal tests can opt in to zerobox for whiteboxing
  - [#1076](https://github.com/mikavilpas/tui-sandbox/pull/1076) | refactor(zerobox): use builtin zerobox `resolveBinary()`
    - 👉🏻 **[#1077](https://github.com/mikavilpas/tui-sandbox/pull/1077)** | fix(zerobox): allow /dev/tty access on macOS only, linux seems broken 👈🏻