### PR TITLE
feat: describe where to put a custom tui-sandbox config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "pnpx oxlint --type-aware --deny-warnings && eslint --max-warnings=0 .",
     "markdownlint": "rumdl check",
     "prettier": "prettier --check .",
-    "test": "vitest run",
+    "test": "vitest",
     "tui": "pnpm --filter=library build && pnpm --filter integration-tests exec tui"
   },
   "devDependencies": {

--- a/packages/library/src/scripts/resolveTuiConfig.ts
+++ b/packages/library/src/scripts/resolveTuiConfig.ts
@@ -32,7 +32,7 @@ export const resolveTuiConfig = async (cwd: string): Promise<ResolveTuiConfigRes
     file = await import(url.href)
     log(`Found configuration file in ${url.pathname}:`, JSON.stringify(file, null, 2))
   } catch (e) {
-    console.log("Using the default configuration.")
+    console.log(`Using the default configuration. If you want to add a custom config, add it to ${url.pathname}`)
     log("Config load error:", e)
 
     return {


### PR DESCRIPTION
# feat: describe where to put a custom tui-sandbox config file

# chore: pnpm test leaves vitest running in watch mode locally

---

# Pull request stack

- 👉🏻 **[#1127](https://github.com/mikavilpas/tui-sandbox/pull/1127)** | feat: describe where to put a custom tui-sandbox config file 👈🏻