### PR TITLE
refactor(lint): move eslint rules to be linted with oxlint

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -50,6 +50,16 @@
     "@typescript-eslint/no-empty-object-type": "error",
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-namespace": "error",
+    "@typescript-eslint/no-restricted-types": [
+      "error",
+      {
+        "types": {
+          "Omit": "Prefer using Except from type-fest instead. That one checks that the unwanted properties actually exist on the source object. See https://github.com/sindresorhus/type-fest"
+        }
+      }
+    ],
+    "@typescript-eslint/no-shadow": "error",
+    "object-shorthand": "warn",
     "@typescript-eslint/no-require-imports": "error",
     "@typescript-eslint/no-unnecessary-type-constraint": "error",
     "@typescript-eslint/no-unsafe-function-type": "error",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
   "plugins": ["typescript", "import", "unicorn"],
+  "jsPlugins": ["eslint-plugin-import-zod"],
   "categories": {
     "correctness": "warn"
   },
@@ -60,6 +61,7 @@
     ],
     "@typescript-eslint/no-shadow": "error",
     "object-shorthand": "warn",
+    "import-zod/prefer-zod-namespace": "error",
     "@typescript-eslint/no-require-imports": "error",
     "@typescript-eslint/no-unnecessary-type-constraint": "error",
     "@typescript-eslint/no-unsafe-function-type": "error",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,21 +55,12 @@ export default defineConfig([
       "@typescript-eslint/no-unnecessary-condition": ["warn", { allowConstantLoopConditions: true }],
       "no-only-tests/no-only-tests": "warn",
       "@typescript-eslint/require-await": "off",
-      "object-shorthand": "warn",
 
       "no-restricted-syntax": [
         "error",
         {
           selector: "TSEnumDeclaration",
           message: "Don't declare enums",
-        },
-      ],
-      "@typescript-eslint/no-restricted-types": [
-        "error",
-        {
-          types: {
-            Omit: "Prefer using Except from type-fest instead. That one checks that the unwanted properties actually exist on the source object. See https://github.com/sindresorhus/type-fest",
-          },
         },
       ],
 
@@ -80,11 +71,6 @@ export default defineConfig([
           allowBoolean: true,
         },
       ],
-      "@typescript-eslint/consistent-type-imports": "error",
-      "@typescript-eslint/no-import-type-side-effects": "error",
-      "@typescript-eslint/explicit-module-boundary-types": ["warn"],
-      "no-shadow": "off",
-      "@typescript-eslint/no-shadow": ["error"],
 
       "lines-between-class-members": [
         "error",
@@ -94,23 +80,7 @@ export default defineConfig([
         },
       ],
 
-      "no-empty-function": [
-        "error",
-        {
-          allow: ["constructors"],
-        },
-      ],
-
-      "no-return-await": "off",
-      "@typescript-eslint/return-await": "error",
       "no-useless-constructor": "off",
-
-      "no-void": [
-        "error",
-        {
-          allowAsStatement: true,
-        },
-      ],
 
       "@typescript-eslint/no-unused-vars": "off",
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,5 @@
 import eslintConfigPrettier from "eslint-config-prettier"
 import eslintPluginImportX from "eslint-plugin-import-x"
-import importZod from "eslint-plugin-import-zod"
 import noOnlyTests from "eslint-plugin-no-only-tests"
 import oxlint from "eslint-plugin-oxlint"
 import { defineConfig } from "eslint/config"
@@ -25,7 +24,6 @@ export default defineConfig([
   tseslint.configs.strictTypeChecked,
   eslintPluginImportX.flatConfigs.recommended,
   eslintPluginImportX.flatConfigs.typescript,
-  importZod.configs.recommended,
 
   {
     files: ["packages/integration-tests/cypress/support/tui-sandbox.ts"],


### PR DESCRIPTION
# refactor(lint): use eslint-plugin-import-zod via oxlint

# refactor(lint): move eslint rules to be linted with oxlint

---

# Pull request stack

- 👉🏻 **[#1149](https://github.com/mikavilpas/tui-sandbox/pull/1149)** | refactor(lint): move eslint rules to be linted with oxlint 👈🏻