### PR TITLE
fix: tui-sandbox-template supports `nodenext` module resolution

### DIFF
--- a/packages/integration-tests/cypress/e2e/neovim.cy.ts
+++ b/packages/integration-tests/cypress/e2e/neovim.cy.ts
@@ -1,8 +1,8 @@
 import { flavors } from "@catppuccin/palette"
 import { rgbify } from "@tui-sandbox/library"
 import assert from "assert"
-import type { MyNeovimAppName, MyTestDirectoryFile } from "../../MyTestDirectory"
-import type { MyBlockingCommandClientInput } from "../support/tui-sandbox"
+import type { MyNeovimAppName, MyTestDirectoryFile } from "../../MyTestDirectory.js"
+import type { MyBlockingCommandClientInput } from "../support/tui-sandbox.js"
 
 describe("neovim features", () => {
   it("can load a custom init.lua file from the .config/nvim directory", () => {

--- a/packages/integration-tests/cypress/support/tui-sandbox.ts
+++ b/packages/integration-tests/cypress/support/tui-sandbox.ts
@@ -24,7 +24,7 @@ import type {
   TestDirectory,
 } from "@tui-sandbox/library/server"
 import type { OverrideProperties } from "type-fest"
-import type { MyNeovimAppName, MyTestDirectory, MyTestDirectoryFile } from "../../MyTestDirectory"
+import type { MyNeovimAppName, MyTestDirectory, MyTestDirectoryFile } from "../../MyTestDirectory.js"
 
 export type TerminalTestApplicationContext = {
   /** Types text into the terminal, making the terminal application receive the

--- a/packages/integration-tests/tsconfig.json
+++ b/packages/integration-tests/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "skipLibCheck": true,
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "target": "ESNext",
     "rootDir": ".",
     "isolatedModules": true,

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -13,19 +13,19 @@
   "exports": {
     ".": {
       "types": "./dist/src/client/index.d.ts",
-      "import": "./dist/src/client/index.js"
+      "default": "./dist/src/client/index.js"
     },
     "./browser/neovim-client.js": {
       "types": "./dist/src/browser/neovim-client.d.ts",
-      "import": "./dist/src/browser/neovim-client.js"
+      "default": "./dist/src/browser/neovim-client.js"
     },
     "./client": {
       "types": "./dist/src/client/index.d.ts",
-      "import": "./dist/src/client/index.js"
+      "default": "./dist/src/client/index.js"
     },
     "./server": {
       "types": "./dist/src/server/index.d.ts",
-      "import": "./dist/src/server/index.js"
+      "default": "./dist/src/server/index.js"
     },
     "./dist/*": "./dist/*",
     "./src/*": "./dist/src/*"

--- a/packages/library/src/server/cypress-support/tui-sandbox-template.ts
+++ b/packages/library/src/server/cypress-support/tui-sandbox-template.ts
@@ -24,7 +24,7 @@ import type {
   TestDirectory,
 } from "@tui-sandbox/library/server"
 import type { OverrideProperties } from "type-fest"
-import type { MyNeovimAppName, MyTestDirectory, MyTestDirectoryFile } from "../../MyTestDirectory"
+import type { MyNeovimAppName, MyTestDirectory, MyTestDirectoryFile } from "../../MyTestDirectory.js"
 
 export type TerminalTestApplicationContext = {
   /** Types text into the terminal, making the terminal application receive the


### PR DESCRIPTION
# fix: tui-sandbox-template supports `nodenext` module resolution

**Issue:**

Currently the codegen uses adds imports to `MyTestDirectory` without the `.js` extension, which causes issues when the consuming project uses `nodenext` module resolution.

**Solution:**

Add the extension. This is the standard way to import local files in ESM, and it works with both `nodenext` and `bundler` module resolutions.

Resources:

- https://nodejs.org/docs/latest-v24.x/api/packages.html

---

# Pull request stack

- 👉🏻 **[#1153](https://github.com/mikavilpas/tui-sandbox/pull/1153)** | fix: tui-sandbox-template supports `nodenext` module resolution 👈🏻