### PR TITLE
chore(mise): use the github backend to install emmylua-analyzer-rust

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
 
           ubi --project mikefarah/yq
 
-          VERSION=$(yq '.tools."ubi:EmmyLuaLs/emmylua-analyzer-rust".version' mise.toml)
+          VERSION=$(yq '.tools."github:EmmyLuaLs/emmylua-analyzer-rust".version' mise.toml)
           ubi --project EmmyLuaLs/emmylua-analyzer-rust --tag "$VERSION" --exe emmylua_ls --matching-regex "^emmylua_ls"
 
           mise install cowsay

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -1,4 +1,4 @@
-settings.disable_tools = ["ubi:EmmyLuaLs/emmylua-analyzer-rust"]
+settings.disable_tools = ["github:EmmyLuaLs/emmylua-analyzer-rust"]
 
 [tools]
 jq = "1.8.1"

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 disable_tools = ["node"]
 
 [tools]
-"ubi:EmmyLuaLs/emmylua-analyzer-rust" = { version = "0.23.1", exe = "emmylua_ls", matching_regex = "^emmylua_ls" }
+"github:EmmyLuaLs/emmylua-analyzer-rust" = { version = "0.23.1", asset_pattern = "emmylua_ls-*" }
 "github:rvben/rumdl" = "0.1.91"
 
 # small sample application that can be installed with mise and used in the test


### PR DESCRIPTION
# chore(mise): use the github backend to install emmylua-analyzer-rust

The ubi backend is deprecated - github should be used instead.

---

# Pull request stack

- 👉🏻 **[#1185](https://github.com/mikavilpas/tui-sandbox/pull/1185)** | chore(mise): use the github backend to install emmylua-analyzer-rust 👈🏻