### PR TITLE
chore: fix pnpm11 not being able to use non-committed bin files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,7 @@ export default defineConfig([
       "packages/library/vite.config.js",
       "packages/library/src/server/cypress-support/tui-sandbox-template.ts",
       "knip.config.ts",
+      "packages/library/bin/tui.js",
     ],
   },
 

--- a/packages/library/bin/tui.js
+++ b/packages/library/bin/tui.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/src/scripts/tui.js"

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -33,9 +33,10 @@
   "main": "./dist/src/client/index.js",
   "types": "./dist/src/client/index.d.ts",
   "bin": {
-    "tui": "dist/src/scripts/tui.js"
+    "tui": "bin/tui.js"
   },
   "files": [
+    "bin",
     "dist",
     "src/server/cypress-support/tui-sandbox-template.ts"
   ],


### PR DESCRIPTION
# chore: fix pnpm11 not being able to use non-committed bin files

This seems to affect local development only.

---

# Pull request stack

- 👉🏻 **[#1186](https://github.com/mikavilpas/tui-sandbox/pull/1186)** | chore: fix pnpm11 not being able to use non-committed bin files 👈🏻