### PR TITLE
chore: ignore arethetypeswrong package tarballs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ packages/library/vite.config.js.timestamp*
 packages/integration-tests/dist/tsconfig.tsbuildinfo
 .oxlintrc.json.bak
 .claude
+packages/library/*.tgz


### PR DESCRIPTION
# chore: ignore arethetypeswrong package tarballs

This prevents watchers like watchexec from triggering a rerun when the file is added - now it will be ignored.

---

# Pull request stack

- 👉🏻 **[#1277](https://github.com/mikavilpas/tui-sandbox/pull/1277)** | chore: ignore arethetypeswrong package tarballs 👈🏻