### PR TITLE
feat: create unique XDG_RUNTIME_DIR for binding test specific sockets

### DIFF
--- a/packages/library/src/server/applications/neovim/NeovimApplication.ts
+++ b/packages/library/src/server/applications/neovim/NeovimApplication.ts
@@ -10,6 +10,7 @@ import type { TestDirectory, TestEnvironmentCommonEnvironmentVariables } from ".
 import { DisposableSingleApplication } from "../../utilities/DisposableSingleApplication.js"
 import type { Lazy } from "../../utilities/Lazy.js"
 import { TerminalApplication } from "../../utilities/TerminalApplication.js"
+import { XdgRuntimeDirectory } from "./environment/XdgRuntimeDirectory.js"
 import { connectNeovimApi } from "./NeovimJavascriptApiClient.js"
 
 const log = debuglog("tui-sandbox-neovim-application")
@@ -92,6 +93,7 @@ type ResettableState = {
   NVIM_APPNAME: string | undefined
   socketPath: string
   client: Lazy<Promise<NeovimApiClient>>
+  xdgRuntimeDirectory: XdgRuntimeDirectory
 }
 
 export class NeovimApplication implements AsyncDisposable {
@@ -159,11 +161,14 @@ export class NeovimApplication implements AsyncDisposable {
     const socketPath = `${tmpdir()}/tui-sandbox-nvim-socket-${id}`
     neovimArguments.push("--listen", socketPath)
 
+    const xdgRuntimeDirectory = await XdgRuntimeDirectory.create(testDirectory.rootPathAbsolute)
+
     const stdout = this.events
 
     await this.application.startNextAndKillCurrent(async () => {
       const env = NeovimApplication.getEnvironmentVariables(
         testDirectory,
+        xdgRuntimeDirectory.path,
         startArgs.NVIM_APPNAME,
         startArgs.additionalEnvironmentVariables
       )
@@ -192,6 +197,7 @@ export class NeovimApplication implements AsyncDisposable {
       socketPath,
       NVIM_APPNAME: startArgs.NVIM_APPNAME,
       client: connectNeovimApi(socketPath),
+      xdgRuntimeDirectory,
     }
 
     log(`🚀 Started Neovim instance ${processId} (NVIM_APPNAME: ${startArgs.NVIM_APPNAME})`)
@@ -199,6 +205,7 @@ export class NeovimApplication implements AsyncDisposable {
 
   public static getEnvironmentVariables(
     testDirectory: TestDirectory,
+    xdgRuntimeDir: string,
     NVIM_APPNAME: string | undefined,
     additionalEnvironmentVariables?: Record<string, string>
   ): Record<string, string> {
@@ -208,6 +215,7 @@ export class NeovimApplication implements AsyncDisposable {
         HOME: testDirectory.rootPathAbsolute,
         XDG_CONFIG_HOME: join(testDirectory.rootPathAbsolute, ".config"),
         XDG_DATA_HOME: join(testDirectory.testEnvironmentPath, ".repro", "data"),
+        XDG_RUNTIME_DIR: xdgRuntimeDir,
         TUI_SANDBOX_TEST_ENVIRONMENT_PATH: testDirectory.testEnvironmentPath,
       } satisfies TestEnvironmentCommonEnvironmentVariables),
       NVIM_APPNAME: NVIM_APPNAME ?? "nvim",
@@ -221,6 +229,7 @@ export class NeovimApplication implements AsyncDisposable {
 
     if (!this.state) return
 
+    await this.state.xdgRuntimeDirectory[Symbol.asyncDispose]()
     exec(`rm -rf ${this.state.testDirectory.rootPathAbsolute}`)
 
     try {

--- a/packages/library/src/server/applications/neovim/api.ts
+++ b/packages/library/src/server/applications/neovim/api.ts
@@ -136,7 +136,18 @@ export async function runBlockingShellCommand(
   const testDirectory = neovim.state?.testDirectory
   assert(testDirectory, `Test directory not found for client id ${input.tabId.tabId}. Maybe neovim's not started yet?`)
 
-  const env = NeovimApplication.getEnvironmentVariables(testDirectory, neovim.state?.NVIM_APPNAME, input.envOverrides)
+  const xdgRuntimeDirectory = neovim.state?.xdgRuntimeDirectory
+  assert(
+    xdgRuntimeDirectory,
+    `XDG runtime directory not found for client id ${input.tabId.tabId}. Maybe neovim's not started yet?`
+  )
+
+  const env = NeovimApplication.getEnvironmentVariables(
+    testDirectory,
+    xdgRuntimeDirectory.path,
+    neovim.state?.NVIM_APPNAME,
+    input.envOverrides
+  )
   return executeBlockingShellCommand(testDirectory, input, signal, allowFailure, env)
 }
 

--- a/packages/library/src/server/applications/neovim/environment/TempDirectory.ts
+++ b/packages/library/src/server/applications/neovim/environment/TempDirectory.ts
@@ -6,8 +6,8 @@ export type TestTempDirPrefix = "test-temp-dir-"
 export class TempDirectory implements Disposable {
   private constructor(public readonly path: string) {}
 
-  public static create(): TempDirectory {
-    const tmp = fs.mkdtempSync("test-temp-dir-" satisfies TestTempDirPrefix)
+  public static create(prefix: `${string}-` = "test-temp-dir-" satisfies TestTempDirPrefix): TempDirectory {
+    const tmp = fs.mkdtempSync(prefix)
     const absolutePath = nodePath.resolve(tmp)
     return new TempDirectory(absolutePath)
   }

--- a/packages/library/src/server/applications/neovim/environment/XdgRuntimeDirectory.test.ts
+++ b/packages/library/src/server/applications/neovim/environment/XdgRuntimeDirectory.test.ts
@@ -1,0 +1,66 @@
+import { existsSync, lstatSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import { expect, it } from "vitest"
+import { TempDirectory } from "./TempDirectory.js"
+import type { XdgRuntimeDirPrefix } from "./XdgRuntimeDirectory.js"
+import { XdgRuntimeDirectory } from "./XdgRuntimeDirectory.js"
+
+const newTestDir = () => TempDirectory.create("tui-test-")
+
+/** Whether a symlink file exists at `path`, without following it (so a dangling
+ * link still counts as existing). Plain `existsSync` follows the link and would
+ * report `false` for a dangling symlink, hiding whether the link was removed. */
+const symlinkFileExists = (path: string): boolean => {
+  try {
+    return lstatSync(path).isSymbolicLink()
+  } catch {
+    return false
+  }
+}
+
+it("creates a uniquely named directory under the system temp dir", async () => {
+  using testDir = newTestDir()
+  await using dir = await XdgRuntimeDirectory.create(testDir.path)
+
+  expect(existsSync(dir.path)).toBe(true)
+  expect(dir.path).toContain("tui-xdg-" satisfies XdgRuntimeDirPrefix)
+})
+
+it("removes the directory and the symlink when disposed", async () => {
+  using testDir = newTestDir()
+
+  let createdPath: string
+  let createdSymlinkPath: string
+  {
+    await using dir = await XdgRuntimeDirectory.create(testDir.path)
+    createdPath = dir.path
+    createdSymlinkPath = dir.symlinkPath
+    expect(existsSync(createdPath)).toBe(true)
+    expect(symlinkFileExists(createdSymlinkPath)).toBe(true)
+  }
+
+  // checked while `testDir` is still alive, so this asserts the dispose itself
+  // unlinked the symlink (rather than the test directory cleanup doing it)
+  expect(existsSync(createdPath)).toBe(false)
+  expect(symlinkFileExists(createdSymlinkPath)).toBe(false)
+})
+
+it("rejects (and does not leak a temp dir) when the symlink cannot be created", async () => {
+  // a non-existent parent makes the symlink() call fail with ENOENT
+  const missingTestDir = join(tmpdir(), "does-not-exist-3f9c1a", "nested")
+  await expect(XdgRuntimeDirectory.create(missingTestDir)).rejects.toThrow()
+})
+
+it("stays well under the OS Unix-socket path limit (this is the reason it exists)", async () => {
+  // The directory holds Unix domain sockets (e.g. yazi appends
+  // `/yazi+<uid>/.dds.sock`). The full socket path must fit in `sun_path`
+  // (~104 bytes on macOS, ~108 on Linux), so the directory itself must leave
+  // ample room.
+  using testDir = newTestDir()
+  await using dir = await XdgRuntimeDirectory.create(testDir.path)
+
+  const exampleSocketPath = join(dir.path, "yazi+1000", ".dds.sock")
+  // Use the stricter macOS limit as the bound so it holds on both platforms.
+  expect(exampleSocketPath.length).toBeLessThan(104)
+})

--- a/packages/library/src/server/applications/neovim/environment/XdgRuntimeDirectory.ts
+++ b/packages/library/src/server/applications/neovim/environment/XdgRuntimeDirectory.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, rm, symlink } from "fs/promises"
+import { tmpdir } from "os"
+import { join } from "path"
+import { debuglog } from "util"
+
+const log = debuglog("tui-sandbox.XdgRuntimeDirectory")
+
+export type XdgRuntimeDirPrefix = "tui-xdg-"
+
+/**
+ * A short-lived, uniquely named directory used as `$XDG_RUNTIME_DIR` for a
+ * single application instance. Disposing it removes the directory (and anything
+ * the application created inside it, such as sockets).
+ *
+ * It is created under the system temp directory. `$XDG_RUNTIME_DIR` holds Unix
+ * domain sockets (for example yazi's DDS `.dds.sock`), and socket paths have a
+ * hard OS length limit (~104 bytes on macOS, ~108 on Linux). The deep path of
+ * a test directory easily exceeds it, which makes `bind()` fail with
+ * `ENAMETOOLONG` so the socket silently never appears. Keeping this directory
+ * shallow leaves room for the socket name the application appends.
+ *
+ * For discoverability while debugging, a `.xdg-runtime` symlink pointing at
+ * {@link path} is also created inside the unique test directory. The symlink is
+ * never used as `$XDG_RUNTIME_DIR` itself (that is always {@link path}, the
+ * short one), so it does not affect the socket path length.
+ */
+export class XdgRuntimeDirectory implements AsyncDisposable {
+  private constructor(
+    public readonly path: string,
+    public readonly symlinkPath: string
+  ) {}
+
+  public static async create(uniqueTestDirectory: string): Promise<XdgRuntimeDirectory> {
+    const path = await mkdtemp(join(tmpdir(), "tui-xdg-" satisfies XdgRuntimeDirPrefix))
+
+    // symlink it to the unique test directory for discoverability while
+    // debugging
+    const symlinkPath = join(uniqueTestDirectory, ".xdg-runtime")
+    try {
+      await symlink(path, symlinkPath, "junction")
+    } catch (e) {
+      // don't leak the temp directory if the symlink could not be created
+      await rm(path, { recursive: true, force: true, maxRetries: 5 })
+      throw e
+    }
+
+    return new XdgRuntimeDirectory(path, symlinkPath)
+  }
+
+  public async [Symbol.asyncDispose](): Promise<void> {
+    log(`Removing XDG_RUNTIME_DIR ${this.path}`)
+    await rm(this.path, { recursive: true, force: true, maxRetries: 5 })
+
+    log(`Removing XDG_RUNTIME_DIR symlink ${this.symlinkPath}`)
+    await rm(this.symlinkPath, { force: true })
+  }
+}

--- a/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
+++ b/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
@@ -6,6 +6,7 @@ import { debuglog } from "util"
 import type { TestDirectory, TestEnvironmentCommonEnvironmentVariables } from "../../types.js"
 import { DisposableSingleApplication } from "../../utilities/DisposableSingleApplication.js"
 import { TerminalApplication } from "../../utilities/TerminalApplication.js"
+import { XdgRuntimeDirectory } from "../neovim/environment/XdgRuntimeDirectory.js"
 import type { StdoutOrStderrMessage, TerminalDimensions } from "../neovim/NeovimApplication.js"
 
 export type { StdoutOrStderrMessage }
@@ -14,6 +15,7 @@ const log = debuglog("tui-sandbox.terminal.TerminalTestApplication")
 
 type ResettableState = {
   testDirectory: TestDirectory
+  xdgRuntimeDirectory: XdgRuntimeDirectory
 }
 
 export type StartTerminalGenericArguments = {
@@ -45,10 +47,16 @@ export default class TerminalTestApplication implements AsyncDisposable {
     // TODO could check if the command is executable
     const terminalArguments = startArgs.commandToRun.slice(1)
 
+    const xdgRuntimeDirectory = await XdgRuntimeDirectory.create(testDirectory.rootPathAbsolute)
+
     const stdout = this.events
 
     await this.application.startNextAndKillCurrent(async () => {
-      const env = this.getEnvironmentVariables(testDirectory, startArgs.additionalEnvironmentVariables)
+      const env = this.getEnvironmentVariables(
+        testDirectory,
+        xdgRuntimeDirectory.path,
+        startArgs.additionalEnvironmentVariables
+      )
       return TerminalApplication.start({
         command,
         args: terminalArguments,
@@ -72,13 +80,14 @@ export default class TerminalTestApplication implements AsyncDisposable {
       "TerminalApplication was started without a process ID. This is a bug - please open an issue."
     )
 
-    this.state = { testDirectory }
+    this.state = { testDirectory, xdgRuntimeDirectory }
 
     log(`🚀 Started Terminal instance ${processId}`)
   }
 
   public getEnvironmentVariables(
     testDirectory: TestDirectory,
+    xdgRuntimeDir: string,
     additionalEnvironmentVariables?: Record<string, string>
   ): Record<string, string> {
     return {
@@ -86,6 +95,7 @@ export default class TerminalTestApplication implements AsyncDisposable {
       HOME: testDirectory.rootPathAbsolute,
       XDG_CONFIG_HOME: join(testDirectory.rootPathAbsolute, ".config"),
       XDG_DATA_HOME: join(testDirectory.testEnvironmentPath, ".repro", "data"),
+      XDG_RUNTIME_DIR: xdgRuntimeDir,
       TUI_SANDBOX_TEST_ENVIRONMENT_PATH: testDirectory.testEnvironmentPath,
       ...additionalEnvironmentVariables,
     } satisfies TestEnvironmentCommonEnvironmentVariables
@@ -95,6 +105,8 @@ export default class TerminalTestApplication implements AsyncDisposable {
     await this.application[Symbol.asyncDispose]()
 
     if (!this.state) return
+
+    await this.state.xdgRuntimeDirectory[Symbol.asyncDispose]()
 
     exec(`rm -rf ${this.state.testDirectory.rootPathAbsolute}`)
 

--- a/packages/library/src/server/applications/terminal/api.ts
+++ b/packages/library/src/server/applications/terminal/api.ts
@@ -84,6 +84,12 @@ export async function runBlockingShellCommand(
   const testDirectory = app.state?.testDirectory
   assert(testDirectory, `Test directory not found for client id ${input.tabId.tabId}. Maybe neovim's not started yet?`)
 
-  const env = app.getEnvironmentVariables(testDirectory, input.envOverrides)
+  const xdgRuntimeDirectory = app.state?.xdgRuntimeDirectory
+  assert(
+    xdgRuntimeDirectory,
+    `XDG runtime directory not found for client id ${input.tabId.tabId}. Maybe it's not started yet?`
+  )
+
+  const env = app.getEnvironmentVariables(testDirectory, xdgRuntimeDirectory.path, input.envOverrides)
   return executeBlockingShellCommand(testDirectory, input, signal, allowFailure, env)
 }

--- a/packages/library/src/server/types.ts
+++ b/packages/library/src/server/types.ts
@@ -57,6 +57,19 @@ export type TestEnvironmentCommonEnvironmentVariables = {
    */
   XDG_DATA_HOME: string
 
+  /** There is a single base directory relative to which user-specific runtime
+   * files and other file objects should be placed. This directory is defined
+   * by the environment variable $XDG_RUNTIME_DIR.
+   *
+   * $XDG_RUNTIME_DIR defines the base directory relative to which
+   * user-specific non-essential runtime files and other file objects (such as
+   * sockets, named pipes, ...) should be stored. The directory MUST be owned
+   * by the user, and they MUST be the only one having read and write access to
+   * it. Its Unix access mode MUST be 0700.
+   *
+   * https://specifications.freedesktop.org/basedir/latest/ */
+  XDG_RUNTIME_DIR: string
+
   /** The path to the test environment directory, which is the blueprint for
    * the test directory.
    * @example /Users/mikavilpas/git/tui-sandbox/packages/integration-tests/test-environment


### PR DESCRIPTION
# feat: create unique XDG_RUNTIME_DIR for binding test specific sockets

**Issue:**

Many applications such as yazi communicate between processes using sockets. Currently they share the same XDG_RUNTIME_DIR by default, which means tests are not isolated on the socket level, even though all test directories are isolated.

**Solution:**

Create and use a unique XDG_RUNTIME_DIR for each test directory to fix it.

There is a limit to how long the socket path can be, so create the unique XDG_RUNTIME_DIR inside a short directory path, and symlink it to the test directory so it can still be easily located when inspecting the test directory.

# chore: allow reusing TempDirectory for tests

The class is very reusable now that we allow customizing the unique prefix. It will be very useful for tests.

---

# Pull request stack

- 👉🏻 **[#1278](https://github.com/mikavilpas/tui-sandbox/pull/1278)** | feat: create unique XDG_RUNTIME_DIR for binding test specific sockets 👈🏻