### PR TITLE
ci: releasing uses OIDC, drop `NODE_AUTH_TOKEN` from env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,5 +55,3 @@ jobs:
             exit 0
           fi
           pnpm publish packages/library --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}


### PR DESCRIPTION
# ci: releasing uses OIDC, drop `NODE_AUTH_TOKEN` from env

---

# Pull request stack

- 👉🏻 **[#1281](https://github.com/mikavilpas/tui-sandbox/pull/1281)** | ci: releasing uses OIDC, drop `NODE_AUTH_TOKEN` from env 👈🏻