### PR TITLE
ci: no need to install yq as it comes preinstalled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,8 +82,6 @@ jobs:
               https://raw.githubusercontent.com/houseabsolute/ubi/master/bootstrap/bootstrap-ubi.sh |
               TARGET="$HOME/.local/bin" sh
 
-          ubi --project mikefarah/yq
-
           VERSION=$(yq '.tools."github:EmmyLuaLs/emmylua-analyzer-rust".version' mise.toml)
           ubi --project EmmyLuaLs/emmylua-analyzer-rust --tag "$VERSION" --exe emmylua_ls --matching-regex "^emmylua_ls"
 


### PR DESCRIPTION
# ci: no need to install yq as it comes preinstalled

https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md already contains `yq 4.53.3`

---

# Pull request stack

- 👉🏻 **[#1313](https://github.com/mikavilpas/tui-sandbox/pull/1313)** | ci: no need to install yq as it comes preinstalled 👈🏻