### PR TITLE
feat: add support for the oxfmt formatter

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -72,6 +72,7 @@
     "@types/node": "24.13.2",
     "cypress": "15.18.0",
     "nodemon": "3.1.14",
+    "oxfmt": "0.56.0",
     "prettier": "3.9.3",
     "type-fest": "5.7.0",
     "vite": "8.1.0",
@@ -79,6 +80,7 @@
   },
   "peerDependencies": {
     "cypress": "^13 || ^14 || ^15",
+    "oxfmt": ">= 0.56.0",
     "prettier": ">= 3.3.3",
     "type-fest": ">= 4.27.0",
     "typescript": ">= 5.6.3",

--- a/packages/library/src/server/dirtree/index.ts
+++ b/packages/library/src/server/dirtree/index.ts
@@ -6,7 +6,7 @@ import type { Dree } from "dree"
 import { scan, Type } from "dree"
 
 import type { TestServerConfig } from "../updateTestdirectorySchemaFile.js"
-import { formatCode } from "../utilities/format.js"
+import { formatCode, isTypeScriptPath } from "../utilities/format.js"
 import { jsonToZod } from "./json-to-zod.js"
 
 const log = debuglog("tui-sandbox.dirtree")
@@ -141,6 +141,7 @@ export async function buildTestDirectorySchema(config: TestServerConfig): Promis
   const unformatted = await buildSchemaForDirectoryTree(dree, "MyTestDirectory", config)
 
   const { outputFilePath } = config.directories
+  assert(isTypeScriptPath(outputFilePath), `outputFilePath must be a .ts file, got: ${outputFilePath}`)
 
   const cacheKey = JSON.stringify([config.formatter.use, outputFilePath, unformatted])
   if (lastFormattedSchema?.key === cacheKey) {
@@ -148,7 +149,7 @@ export async function buildTestDirectorySchema(config: TestServerConfig): Promis
     return lastFormattedSchema.value
   }
 
-  const formatted = await formatCode(config.formatter, unformatted)
+  const formatted = await formatCode(config.formatter, unformatted, outputFilePath)
   lastFormattedSchema = { key: cacheKey, value: formatted }
   return formatted
 }

--- a/packages/library/src/server/updateTestdirectorySchemaFile.ts
+++ b/packages/library/src/server/updateTestdirectorySchemaFile.ts
@@ -25,7 +25,10 @@ const neovimIntegration = z.strictObject({
 
 export type FormatterConfig = z.output<typeof formatterConfigSchema>
 const formatterConfigSchema = z
-  .discriminatedUnion("use", [z.strictObject({ use: z.literal("prettier") })])
+  .discriminatedUnion("use", [
+    z.strictObject({ use: z.literal("prettier") }),
+    z.strictObject({ use: z.literal("oxfmt") }),
+  ])
   .optional()
   .default({ use: "prettier" })
 

--- a/packages/library/src/server/utilities/format.test.ts
+++ b/packages/library/src/server/utilities/format.test.ts
@@ -16,3 +16,23 @@ describe("prettier", () => {
     `)
   })
 })
+
+describe("oxfmt", () => {
+  it("formats TypeScript, including type syntax", async () => {
+    // the oxfmt cli should walk up the directory tree and discover the
+    // tui-sandbox oxfmt config file, inheriting its code style. This should be
+    // visible in the formatting result.
+    const result = await formatCode({ use: "oxfmt" }, unformattedTypeScript)
+    expect(result).toMatchInlineSnapshot(`
+      "export type Foo = z.infer<typeof Bar>
+      const x = { a: 1, b: 2 }
+      "
+    `)
+  })
+
+  it("throws when the code cannot be parsed", async () => {
+    await expect(formatCode({ use: "oxfmt" }, "const x = {{{ invalid")).rejects.toThrow(
+      /Error formatting code with oxfmt/
+    )
+  })
+})

--- a/packages/library/src/server/utilities/format.ts
+++ b/packages/library/src/server/utilities/format.ts
@@ -1,16 +1,69 @@
+import { spawn } from "node:child_process"
+import { readFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import path from "node:path"
 import { fileURLToPath } from "node:url"
+
+import * as z from "zod"
 
 import type { FormatterConfig } from "../updateTestdirectorySchemaFile.js"
 
 const __filename = fileURLToPath(import.meta.url)
+const require = createRequire(import.meta.url)
+export const isTypeScriptPath = (filePath: string): filePath is `${string}.ts` => filePath.endsWith(".ts")
 
-export const formatCode = async (config: FormatterConfig, code: string): Promise<string> => {
-  config.use satisfies "prettier"
-  const { format, resolveConfig } = await import("prettier")
-  const prettierConfig = await resolveConfig(__filename)
+export const formatCode = async (
+  config: FormatterConfig,
+  code: string,
+  // oxfmt selects its parser from the file name's extension, and (via the CLI)
+  // resolves its config by walking up from the file's directory.
+  fileName: `${string}.ts` = "generated.ts"
+): Promise<string> => {
+  if (config.use === "prettier") {
+    const { format, resolveConfig } = await import("prettier")
+    const prettierConfig = await resolveConfig(__filename)
 
-  return format(code, {
-    ...prettierConfig,
-    parser: "typescript",
+    return format(code, {
+      ...prettierConfig,
+      parser: "typescript",
+    })
+  }
+
+  config.use satisfies "oxfmt"
+  return formatWithOxfmt(code, fileName)
+}
+const oxfmtPackageJsonSchema = z.object({ bin: z.object({ oxfmt: z.string() }) })
+
+const resolveOxfmtCliPath = (): string => {
+  const packageJsonPath = require.resolve("oxfmt/package.json")
+  const contents: unknown = JSON.parse(readFileSync(packageJsonPath, "utf8"))
+  const packageJson = oxfmtPackageJsonSchema.parse(contents)
+  return path.join(path.dirname(packageJsonPath), packageJson.bin.oxfmt)
+}
+
+const formatWithOxfmt = (code: string, fileName: string): Promise<string> => {
+  const oxfmtCliPath = resolveOxfmtCliPath()
+
+  return new Promise<string>((resolve, reject) => {
+    // oxfmt discovers config by walking up from the --stdin-filepath directory,
+    // reads the source from stdin, and writes the formatted result to stdout.
+    const child = spawn(process.execPath, [oxfmtCliPath, `--stdin-filepath=${fileName}`])
+
+    let stdout = ""
+    let stderr = ""
+    child.stdout.on("data", chunk => (stdout += String(chunk)))
+    child.stderr.on("data", chunk => (stderr += String(chunk)))
+    child.on("error", reject)
+    child.on("close", exitCode => {
+      if (exitCode === 0) {
+        resolve(stdout)
+      } else {
+        reject(new Error(`Error formatting code with oxfmt (exit code ${String(exitCode)}): ${stderr.trim()}`))
+      }
+    })
+
+    // guard against EPIPE if oxfmt exits before consuming all of stdin
+    child.stdin.on("error", reject)
+    child.stdin.end(code)
   })
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       nodemon:
         specifier: 3.1.14
         version: 3.1.14
+      oxfmt:
+        specifier: 0.56.0
+        version: 0.56.0
       prettier:
         specifier: 3.9.3
         version: 3.9.3


### PR DESCRIPTION
# feat: add support for the oxfmt formatter

Projects that want to use oxfmt instead of prettier can now format the generated code using it.

---

# Pull request stack

- 👉🏻 **[#1317](https://github.com/mikavilpas/tui-sandbox/pull/1317)** | feat: add support for the oxfmt formatter 👈🏻
  - [#1322](https://github.com/mikavilpas/tui-sandbox/pull/1322) | test: integration-tests use oxfmt as the codegen formatter