### PR TITLE
fix: config validation errors are not shown

### DIFF
--- a/packages/library/src/scripts/tui.ts
+++ b/packages/library/src/scripts/tui.ts
@@ -27,7 +27,7 @@ if (major < 24) {
 export const cwd = process.cwd()
 const configResult = await resolveTuiConfig(cwd)
 if (configResult.error) {
-  console.error(configResult.message, configResult.error)
+  console.error(configResult.message, JSON.stringify(configResult.error))
   process.exit(1)
 }
 


### PR DESCRIPTION
# fix: config validation errors are not shown

Before:

```sh
Issues found in the config file { errors: [], properties: { config: { errors: [Array] } } }
```

After:

```sh
Issues found in the config file {"errors":[],"properties":{"config":{"errors":["Unrecognized key: \"a\""]}}}
```

---

# Pull request stack

- 👉🏻 **[#1321](https://github.com/mikavilpas/tui-sandbox/pull/1321)** | fix: config validation errors are not shown 👈🏻