### PR TITLE
test: integration-tests use oxfmt as the codegen formatter

### DIFF
--- a/packages/integration-tests/MyTestDirectory.ts
+++ b/packages/integration-tests/MyTestDirectory.ts
@@ -14,44 +14,26 @@ export const MyTestDirectorySchema = z.object({
   name: z.literal("test-environment/"),
   type: z.literal("directory"),
   contents: z.object({
-    ".bashrc": z.object({
-      name: z.literal(".bashrc"),
-      type: z.literal("file"),
-    }),
+    ".bashrc": z.object({ name: z.literal(".bashrc"), type: z.literal("file") }),
     ".config": z.object({
       name: z.literal(".config/"),
       type: z.literal("directory"),
       contents: z.object({
-        ".gitkeep": z.object({
-          name: z.literal(".gitkeep"),
-          type: z.literal("file"),
-        }),
+        ".gitkeep": z.object({ name: z.literal(".gitkeep"), type: z.literal("file") }),
         nvim: z.object({
           name: z.literal("nvim/"),
           type: z.literal("directory"),
           contents: z.object({
-            "init.lua": z.object({
-              name: z.literal("init.lua"),
-              type: z.literal("file"),
-            }),
-            "prepare.lua": z.object({
-              name: z.literal("prepare.lua"),
-              type: z.literal("file"),
-            }),
+            "init.lua": z.object({ name: z.literal("init.lua"), type: z.literal("file") }),
+            "prepare.lua": z.object({ name: z.literal("prepare.lua"), type: z.literal("file") }),
           }),
         }),
         nvim_alt: z.object({
           name: z.literal("nvim_alt/"),
           type: z.literal("directory"),
           contents: z.object({
-            "init.lua": z.object({
-              name: z.literal("init.lua"),
-              type: z.literal("file"),
-            }),
-            "prepare.lua": z.object({
-              name: z.literal("prepare.lua"),
-              type: z.literal("file"),
-            }),
+            "init.lua": z.object({ name: z.literal("init.lua"), type: z.literal("file") }),
+            "prepare.lua": z.object({ name: z.literal("prepare.lua"), type: z.literal("file") }),
           }),
         }),
       }),
@@ -72,10 +54,7 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("don't_crash_when_modification_contains_unescaped_characters\".lua"),
           type: z.literal("file"),
         }),
-        "set_terminal_title.lua": z.object({
-          name: z.literal("set_terminal_title.lua"),
-          type: z.literal("file"),
-        }),
+        "set_terminal_title.lua": z.object({ name: z.literal("set_terminal_title.lua"), type: z.literal("file") }),
         subdir: z.object({
           name: z.literal("subdir/"),
           type: z.literal("directory"),
@@ -92,50 +71,26 @@ export const MyTestDirectorySchema = z.object({
       name: z.literal("dir with spaces/"),
       type: z.literal("directory"),
       contents: z.object({
-        "file1.txt": z.object({
-          name: z.literal("file1.txt"),
-          type: z.literal("file"),
-        }),
-        "file2.txt": z.object({
-          name: z.literal("file2.txt"),
-          type: z.literal("file"),
-        }),
+        "file1.txt": z.object({ name: z.literal("file1.txt"), type: z.literal("file") }),
+        "file2.txt": z.object({ name: z.literal("file2.txt"), type: z.literal("file") }),
       }),
     }),
-    "file.txt": z.object({
-      name: z.literal("file.txt"),
-      type: z.literal("file"),
-    }),
-    "initial-file.txt": z.object({
-      name: z.literal("initial-file.txt"),
-      type: z.literal("file"),
-    }),
+    "file.txt": z.object({ name: z.literal("file.txt"), type: z.literal("file") }),
+    "initial-file.txt": z.object({ name: z.literal("initial-file.txt"), type: z.literal("file") }),
     "lua-project": z.object({
       name: z.literal("lua-project/"),
       type: z.literal("directory"),
       contents: z.object({
-        ".luarc.json": z.object({
-          name: z.literal(".luarc.json"),
-          type: z.literal("file"),
-        }),
-        "config.lua": z.object({
-          name: z.literal("config.lua"),
-          type: z.literal("file"),
-        }),
-        "init.lua": z.object({
-          name: z.literal("init.lua"),
-          type: z.literal("file"),
-        }),
+        ".luarc.json": z.object({ name: z.literal(".luarc.json"), type: z.literal("file") }),
+        "config.lua": z.object({ name: z.literal("config.lua"), type: z.literal("file") }),
+        "init.lua": z.object({ name: z.literal("init.lua"), type: z.literal("file") }),
       }),
     }),
     "other-subdirectory": z.object({
       name: z.literal("other-subdirectory/"),
       type: z.literal("directory"),
       contents: z.object({
-        "other-sub-file.txt": z.object({
-          name: z.literal("other-sub-file.txt"),
-          type: z.literal("file"),
-        }),
+        "other-sub-file.txt": z.object({ name: z.literal("other-sub-file.txt"), type: z.literal("file") }),
       }),
     }),
     routes: z.object({
@@ -146,14 +101,8 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("posts.$postId/"),
           type: z.literal("directory"),
           contents: z.object({
-            "adjacent-file.txt": z.object({
-              name: z.literal("adjacent-file.txt"),
-              type: z.literal("file"),
-            }),
-            "route.tsx": z.object({
-              name: z.literal("route.tsx"),
-              type: z.literal("file"),
-            }),
+            "adjacent-file.txt": z.object({ name: z.literal("adjacent-file.txt"), type: z.literal("file") }),
+            "route.tsx": z.object({ name: z.literal("route.tsx"), type: z.literal("file") }),
             "should-be-excluded-file.txt": z.object({
               name: z.literal("should-be-excluded-file.txt"),
               type: z.literal("file"),
@@ -166,10 +115,7 @@ export const MyTestDirectorySchema = z.object({
       name: z.literal("subdirectory/"),
       type: z.literal("directory"),
       contents: z.object({
-        "subdirectory-file.txt": z.object({
-          name: z.literal("subdirectory-file.txt"),
-          type: z.literal("file"),
-        }),
+        "subdirectory-file.txt": z.object({ name: z.literal("subdirectory-file.txt"), type: z.literal("file") }),
       }),
     }),
     "symlink-target.txt": z.object({
@@ -181,10 +127,7 @@ export const MyTestDirectorySchema = z.object({
       name: z.literal("symlink-test/"),
       type: z.literal("directory"),
       contents: z.object({
-        "symlink-target.txt": z.object({
-          name: z.literal("symlink-target.txt"),
-          type: z.literal("file"),
-        }),
+        "symlink-target.txt": z.object({ name: z.literal("symlink-target.txt"), type: z.literal("file") }),
       }),
     }),
   }),

--- a/packages/integration-tests/tui-sandbox.config.ts
+++ b/packages/integration-tests/tui-sandbox.config.ts
@@ -3,3 +3,6 @@ import type { TestServerConfig } from "@tui-sandbox/library/dist/src/server/inde
 
 export const config: TestServerConfig = createDefaultConfig(process.cwd(), process.env)
 config.integrations.neovim.NVIM_APPNAMEs = ["nvim", "nvim_alt"]
+config.formatter = {
+  use: "oxfmt",
+}


### PR DESCRIPTION
# test: integration-tests use oxfmt as the codegen formatter

Dogfood the oxfmt formatter since this is what the project already uses since https://github.com/mikavilpas/tui-sandbox/pull/1305

---

# Pull request stack

- 👉🏻 **[#1322](https://github.com/mikavilpas/tui-sandbox/pull/1322)** | test: integration-tests use oxfmt as the codegen formatter 👈🏻