### PR TITLE
fix(mise): mise related test block/slowdown fixes

### DIFF
--- a/packages/integration-tests/cypress/e2e/neovim.cy.ts
+++ b/packages/integration-tests/cypress/e2e/neovim.cy.ts
@@ -346,9 +346,6 @@ describe("neovim features", () => {
       cy.visit("/")
       cy.startNeovim({
         filename: "lua-project/init.lua",
-        additionalEnvironmentVariables: {
-          MISE_YES: "1",
-        },
       }).then(nvim => {
         // wait until text on the start screen is visible
         cy.contains(`require("config")`)

--- a/packages/library/src/server/applications/neovim/NeovimApplication.ts
+++ b/packages/library/src/server/applications/neovim/NeovimApplication.ts
@@ -12,6 +12,7 @@ import type { TestDirectory, TestEnvironmentCommonEnvironmentVariables } from ".
 import { DisposableSingleApplication } from "../../utilities/DisposableSingleApplication.js"
 import type { Lazy } from "../../utilities/Lazy.js"
 import { TerminalApplication } from "../../utilities/TerminalApplication.js"
+import { resolveMiseStateDirectory } from "./environment/resolveMiseStateDirectory.js"
 import { XdgRuntimeDirectory } from "./environment/XdgRuntimeDirectory.js"
 import { connectNeovimApi } from "./NeovimJavascriptApiClient.js"
 
@@ -211,6 +212,7 @@ export class NeovimApplication implements AsyncDisposable {
     NVIM_APPNAME: string | undefined,
     additionalEnvironmentVariables?: Record<string, string>
   ): Record<string, string> {
+    const miseStateDirectory = resolveMiseStateDirectory()
     return {
       ...process.env,
       ...({
@@ -219,6 +221,7 @@ export class NeovimApplication implements AsyncDisposable {
         XDG_DATA_HOME: join(testDirectory.testEnvironmentPath, ".repro", "data"),
         XDG_RUNTIME_DIR: xdgRuntimeDir,
         TUI_SANDBOX_TEST_ENVIRONMENT_PATH: testDirectory.testEnvironmentPath,
+        ...(miseStateDirectory ? { MISE_STATE_DIR: miseStateDirectory } : {}),
       } satisfies TestEnvironmentCommonEnvironmentVariables),
       NVIM_APPNAME: NVIM_APPNAME ?? "nvim",
 

--- a/packages/library/src/server/applications/neovim/NeovimApplication.ts
+++ b/packages/library/src/server/applications/neovim/NeovimApplication.ts
@@ -222,6 +222,7 @@ export class NeovimApplication implements AsyncDisposable {
         XDG_RUNTIME_DIR: xdgRuntimeDir,
         TUI_SANDBOX_TEST_ENVIRONMENT_PATH: testDirectory.testEnvironmentPath,
         ...(miseStateDirectory ? { MISE_STATE_DIR: miseStateDirectory } : {}),
+        MISE_OFFLINE: "1",
       } satisfies TestEnvironmentCommonEnvironmentVariables),
       NVIM_APPNAME: NVIM_APPNAME ?? "nvim",
 

--- a/packages/library/src/server/applications/neovim/environment/resolveMiseStateDirectory.test.ts
+++ b/packages/library/src/server/applications/neovim/environment/resolveMiseStateDirectory.test.ts
@@ -1,0 +1,21 @@
+import { expect, it } from "vitest"
+
+import { resolveMiseStateDirectory } from "./resolveMiseStateDirectory.js"
+
+it("prefers MISE_STATE_DIR when set", () => {
+  expect(
+    resolveMiseStateDirectory({ MISE_STATE_DIR: "/custom/state", XDG_STATE_HOME: "/xdg", HOME: "/home/user" })
+  ).toBe("/custom/state")
+})
+
+it("falls back to $XDG_STATE_HOME/mise", () => {
+  expect(resolveMiseStateDirectory({ XDG_STATE_HOME: "/xdg", HOME: "/home/user" })).toBe("/xdg/mise")
+})
+
+it("falls back to $HOME/.local/state/mise", () => {
+  expect(resolveMiseStateDirectory({ HOME: "/home/user" })).toBe("/home/user/.local/state/mise")
+})
+
+it("returns undefined when nothing is set (mise keeps its default behaviour)", () => {
+  expect(resolveMiseStateDirectory({})).toBeUndefined()
+})

--- a/packages/library/src/server/applications/neovim/environment/resolveMiseStateDirectory.ts
+++ b/packages/library/src/server/applications/neovim/environment/resolveMiseStateDirectory.ts
@@ -1,0 +1,22 @@
+import { join } from "path"
+
+/**
+ * Resolves mise's state directory (which holds its trust database) from the
+ * real environment, so the sandbox can reuse it despite overriding `$HOME`.
+ *
+ * mise resolves it as `$MISE_STATE_DIR`, else `${XDG_STATE_HOME:-$HOME/.local/state}/mise`
+ * (see https://mise.jdx.dev/directories.html), which is what the branches below
+ * replicate.
+ */
+export const resolveMiseStateDirectory = (realEnvironment: NodeJS.ProcessEnv = process.env): string | undefined => {
+  if (realEnvironment["MISE_STATE_DIR"]) {
+    return realEnvironment["MISE_STATE_DIR"]
+  }
+  if (realEnvironment["XDG_STATE_HOME"]) {
+    return join(realEnvironment["XDG_STATE_HOME"], "mise")
+  }
+  if (realEnvironment["HOME"]) {
+    return join(realEnvironment["HOME"], ".local", "state", "mise")
+  }
+  return undefined
+}

--- a/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
+++ b/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
@@ -101,6 +101,7 @@ export default class TerminalTestApplication implements AsyncDisposable {
       XDG_RUNTIME_DIR: xdgRuntimeDir,
       TUI_SANDBOX_TEST_ENVIRONMENT_PATH: testDirectory.testEnvironmentPath,
       ...(miseStateDirectory ? { MISE_STATE_DIR: miseStateDirectory } : {}),
+      MISE_OFFLINE: "1",
       ...additionalEnvironmentVariables,
     } satisfies TestEnvironmentCommonEnvironmentVariables
   }

--- a/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
+++ b/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
@@ -7,6 +7,7 @@ import { debuglog } from "util"
 import type { TestDirectory, TestEnvironmentCommonEnvironmentVariables } from "../../types.js"
 import { DisposableSingleApplication } from "../../utilities/DisposableSingleApplication.js"
 import { TerminalApplication } from "../../utilities/TerminalApplication.js"
+import { resolveMiseStateDirectory } from "../neovim/environment/resolveMiseStateDirectory.js"
 import { XdgRuntimeDirectory } from "../neovim/environment/XdgRuntimeDirectory.js"
 import type { StdoutOrStderrMessage, TerminalDimensions } from "../neovim/NeovimApplication.js"
 
@@ -91,6 +92,7 @@ export default class TerminalTestApplication implements AsyncDisposable {
     xdgRuntimeDir: string,
     additionalEnvironmentVariables?: Record<string, string>
   ): Record<string, string> {
+    const miseStateDirectory = resolveMiseStateDirectory()
     return {
       ...process.env,
       HOME: testDirectory.rootPathAbsolute,
@@ -98,6 +100,7 @@ export default class TerminalTestApplication implements AsyncDisposable {
       XDG_DATA_HOME: join(testDirectory.testEnvironmentPath, ".repro", "data"),
       XDG_RUNTIME_DIR: xdgRuntimeDir,
       TUI_SANDBOX_TEST_ENVIRONMENT_PATH: testDirectory.testEnvironmentPath,
+      ...(miseStateDirectory ? { MISE_STATE_DIR: miseStateDirectory } : {}),
       ...additionalEnvironmentVariables,
     } satisfies TestEnvironmentCommonEnvironmentVariables
   }

--- a/packages/library/src/server/types.ts
+++ b/packages/library/src/server/types.ts
@@ -75,6 +75,13 @@ export type TestEnvironmentCommonEnvironmentVariables = {
    * @example /Users/mikavilpas/git/tui-sandbox/packages/integration-tests/test-environment
    * */
   TUI_SANDBOX_TEST_ENVIRONMENT_PATH: string
+
+  /** Points mise at the real user's state directory so it reuses their existing
+   * trust database instead of prompting to trust config files (which no test can
+   * answer). Trusted configs pass silently; untrusted ones still prompt, keeping
+   * the security check intact. Resolved by resolveMiseStateDirectory.
+   */
+  MISE_STATE_DIR?: string
 }
 
 export type { StartNeovimGenericArguments } from "./applications/neovim/NeovimApplication.js"

--- a/packages/library/src/server/types.ts
+++ b/packages/library/src/server/types.ts
@@ -82,6 +82,15 @@ export type TestEnvironmentCommonEnvironmentVariables = {
    * the security check intact. Resolved by resolveMiseStateDirectory.
    */
   MISE_STATE_DIR?: string
+
+  /** Forbids mise from making network calls while a test runs. Without this,
+   * resolving a tool pinned to "latest" or a missing `npm:`/`cargo:` backend
+   * tool makes mise shell out (e.g. to npm), which is slow, prints update
+   * notices into the terminal, and can push a test past its timeout. Everything
+   * the sandbox needs is installed ahead of time, so offline resolution from
+   * disk is enough at test time.
+   */
+  MISE_OFFLINE: string
 }
 
 export type { StartNeovimGenericArguments } from "./applications/neovim/NeovimApplication.js"


### PR DESCRIPTION
# fix(mise): forbid mise from making network calls during tests

**Issue:**

Mise may wait ~1000ms before launching a mise tool, slowing the tests down.

**Solution:**

Prevent this by forbidding mise from making network calls during tests.

All tests should run offline because they are otherwise not reliable and fast.

# fix(mise): asking if config files may be trusted

**Issue:**

Mise may prompt to ask if config files may be trusted, which no test can answer. This causes tests to hang indefinitely.

It seems to be caused by mise not having access to the real user's state directory, which holds the trust database.

**Solution:**

Use mise's environment variables to give it explicit access to the real user's state directory, resolving the issue.

---

# Pull request stack

- 👉🏻 **[#1325](https://github.com/mikavilpas/tui-sandbox/pull/1325)** | fix(mise): mise related test block/slowdown fixes 👈🏻