### PR TITLE
feat!: mise integration related features are now opt-in

### DIFF
--- a/packages/integration-tests/tui-sandbox.config.ts
+++ b/packages/integration-tests/tui-sandbox.config.ts
@@ -2,6 +2,7 @@ import { createDefaultConfig } from "@tui-sandbox/library/dist/src/server/config
 import type { TestServerConfig } from "@tui-sandbox/library/dist/src/server/index.js"
 
 export const config: TestServerConfig = createDefaultConfig(process.cwd(), process.env)
+config.integrations.mise = {}
 config.integrations.neovim.NVIM_APPNAMEs = ["nvim", "nvim_alt"]
 config.formatter = {
   use: "oxfmt",

--- a/packages/library/src/scripts/commands/commandTuiNeovimExec.ts
+++ b/packages/library/src/scripts/commands/commandTuiNeovimExec.ts
@@ -3,20 +3,20 @@ import { prepareNewTestDirectory } from "../../server/applications/neovim/prepar
 import type { TestServerConfigMetadata } from "../../server/updateTestdirectorySchemaFile.js"
 import type { NeovimExec } from "../parseArguments.js"
 
-export async function commandTuiNeovimExec(command: NeovimExec, config: TestServerConfigMetadata): Promise<void> {
+export async function commandTuiNeovimExec(command: NeovimExec, configMeta: TestServerConfigMetadata): Promise<void> {
   // automatically dispose of the neovim instance when done
-  await using app = new NeovimApplication(config.config.directories.testEnvironmentPath)
+  await using app = new NeovimApplication(configMeta.config.directories.testEnvironmentPath)
   app.events.on("stdout" satisfies StdoutOrStderrMessage, data => {
     console.log(`  neovim output: ${data}`)
   })
-  const testDirectory = await prepareNewTestDirectory(config.config)
+  const testDirectory = await prepareNewTestDirectory(configMeta.config)
   const NVIM_APPNAME = process.env["NVIM_APPNAME"]
 
-  if (NVIM_APPNAME && !config.config.integrations.neovim.NVIM_APPNAMEs.find(n => n === NVIM_APPNAME)) {
+  if (NVIM_APPNAME && !configMeta.config.integrations.neovim.NVIM_APPNAMEs.find(n => n === NVIM_APPNAME)) {
     process.exitCode = 1
     const message = `The NVIM_APPNAME environment variable is set to "${NVIM_APPNAME}", but only the following neovim configurations are known in the configuration file: ${JSON.stringify(
-      config.config.integrations.neovim.NVIM_APPNAMEs,
-    )}. Please set NVIM_APPNAME to one of the configured names or unset it to use the default ("nvim"). Config file path: ${config.configFilePath}`
+      configMeta.config.integrations.neovim.NVIM_APPNAMEs,
+    )}. Please set NVIM_APPNAME to one of the configured names or unset it to use the default ("nvim"). Config file path: ${configMeta.configFilePath}`
 
     console.error(message)
 
@@ -24,6 +24,7 @@ export async function commandTuiNeovimExec(command: NeovimExec, config: TestServ
   }
 
   await app.startNextAndKillCurrent(
+    configMeta.config,
     testDirectory,
     {
       filename: "empty.txt",

--- a/packages/library/src/scripts/tui.ts
+++ b/packages/library/src/scripts/tui.ts
@@ -7,6 +7,7 @@ import { commandTuiNeovimExec } from "./commands/commandTuiNeovimExec.js"
 import { commandTuiNeovimPrepare } from "./commands/commandTuiNeovimPrepare.js"
 import { commandTuiStart, updateGeneratedCode } from "./commands/commandTuiStart.js"
 import { parseArguments } from "./parseArguments.js"
+import type { ResolveTuiConfigResult } from "./resolveTuiConfig.js"
 import { resolveTuiConfig } from "./resolveTuiConfig.js"
 
 //
@@ -25,7 +26,7 @@ if (major < 24) {
 /** The cwd in the user's directory when they are running this script. Not the
  * cwd of the script itself. */
 export const cwd = process.cwd()
-const configResult = await resolveTuiConfig(cwd)
+const configResult: ResolveTuiConfigResult = await resolveTuiConfig(cwd)
 if (configResult.error) {
   console.error(configResult.message, JSON.stringify(configResult.error))
   process.exit(1)

--- a/packages/library/src/server/applications/neovim/NeovimApplication.ts
+++ b/packages/library/src/server/applications/neovim/NeovimApplication.ts
@@ -8,7 +8,12 @@ import { debuglog } from "util"
 
 import type { NeovimClient as NeovimApiClient } from "neovim"
 
-import type { TestDirectory, TestEnvironmentCommonEnvironmentVariables } from "../../types.js"
+import type {
+  MiseIntegrationEnvironmentVariables,
+  TestDirectory,
+  TestEnvironmentCommonEnvironmentVariables,
+} from "../../types.js"
+import type { TestServerConfig } from "../../updateTestdirectorySchemaFile.js"
 import { DisposableSingleApplication } from "../../utilities/DisposableSingleApplication.js"
 import type { Lazy } from "../../utilities/Lazy.js"
 import { TerminalApplication } from "../../utilities/TerminalApplication.js"
@@ -114,6 +119,7 @@ export class NeovimApplication implements AsyncDisposable {
    * Kill the current application and start a new one with the given arguments.
    */
   public async startNextAndKillCurrent(
+    config: TestServerConfig,
     testDirectory: TestDirectory,
     startArgs: StartNeovimGenericArguments,
     terminalDimensions: TerminalDimensions,
@@ -170,6 +176,7 @@ export class NeovimApplication implements AsyncDisposable {
 
     await this.application.startNextAndKillCurrent(async () => {
       const env = NeovimApplication.getEnvironmentVariables(
+        config,
         testDirectory,
         xdgRuntimeDirectory.path,
         startArgs.NVIM_APPNAME,
@@ -207,13 +214,13 @@ export class NeovimApplication implements AsyncDisposable {
   }
 
   public static getEnvironmentVariables(
+    config: TestServerConfig,
     testDirectory: TestDirectory,
     xdgRuntimeDir: string,
     NVIM_APPNAME: string | undefined,
     additionalEnvironmentVariables?: Record<string, string>,
   ): Record<string, string> {
-    const miseStateDirectory = resolveMiseStateDirectory()
-    return {
+    const env = {
       ...process.env,
       ...({
         HOME: testDirectory.rootPathAbsolute,
@@ -221,13 +228,20 @@ export class NeovimApplication implements AsyncDisposable {
         XDG_DATA_HOME: join(testDirectory.testEnvironmentPath, ".repro", "data"),
         XDG_RUNTIME_DIR: xdgRuntimeDir,
         TUI_SANDBOX_TEST_ENVIRONMENT_PATH: testDirectory.testEnvironmentPath,
-        ...(miseStateDirectory ? { MISE_STATE_DIR: miseStateDirectory } : {}),
-        MISE_OFFLINE: "1",
       } satisfies TestEnvironmentCommonEnvironmentVariables),
       NVIM_APPNAME: NVIM_APPNAME ?? "nvim",
-
-      ...additionalEnvironmentVariables,
     }
+
+    if (config.integrations.mise) {
+      const miseStateDirectory = resolveMiseStateDirectory()
+      Object.assign(env, {
+        ...(miseStateDirectory ? { MISE_STATE_DIR: miseStateDirectory } : {}),
+        MISE_OFFLINE: "1",
+      } satisfies MiseIntegrationEnvironmentVariables)
+    }
+
+    Object.assign(env, additionalEnvironmentVariables ?? {})
+    return env
   }
 
   async [Symbol.asyncDispose](): Promise<void> {

--- a/packages/library/src/server/applications/neovim/api.ts
+++ b/packages/library/src/server/applications/neovim/api.ts
@@ -56,6 +56,7 @@ export async function installDependencies(NVIM_APPNAME: string | undefined, conf
     output += data
   })
   await app.startNextAndKillCurrent(
+    config,
     testDirectory,
     {
       filename: "empty.txt",
@@ -105,7 +106,7 @@ export async function start(
   assert(neovim, `Neovim instance not found for client id ${tabId.tabId}`)
 
   const testDirectory = await prepareNewTestDirectory(config)
-  await neovim.startNextAndKillCurrent(testDirectory, options, terminalDimensions)
+  await neovim.startNextAndKillCurrent(config, testDirectory, options, terminalDimensions)
 
   return testDirectory
 }
@@ -125,6 +126,7 @@ export async function sendStdin(options: { tabId: TabId; data: string }): Promis
 }
 
 export async function runBlockingShellCommand(
+  config: TestServerConfig,
   signal: AbortSignal | undefined,
   input: BlockingCommandInput,
   allowFailure: boolean,
@@ -144,6 +146,7 @@ export async function runBlockingShellCommand(
   )
 
   const env = NeovimApplication.getEnvironmentVariables(
+    config,
     testDirectory,
     xdgRuntimeDirectory.path,
     neovim.state?.NVIM_APPNAME,

--- a/packages/library/src/server/applications/neovim/neovimRouter.ts
+++ b/packages/library/src/server/applications/neovim/neovimRouter.ts
@@ -82,7 +82,7 @@ export function createNeovimRouter(config: TestServerConfig) {
     }),
 
     runBlockingShellCommand: trpc.procedure.input(blockingCommandInputSchema).mutation(async options => {
-      return neovim.runBlockingShellCommand(options.signal, options.input, options.input.allowFailure ?? false)
+      return neovim.runBlockingShellCommand(config, options.signal, options.input, options.input.allowFailure ?? false)
     }),
 
     runLuaCode: trpc.procedure.input(luaCodeInputSchema).mutation(options => {

--- a/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
+++ b/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
@@ -4,7 +4,12 @@ import EventEmitter from "events"
 import { join } from "path"
 import { debuglog } from "util"
 
-import type { TestDirectory, TestEnvironmentCommonEnvironmentVariables } from "../../types.js"
+import type {
+  MiseIntegrationEnvironmentVariables,
+  TestDirectory,
+  TestEnvironmentCommonEnvironmentVariables,
+} from "../../types.js"
+import type { TestServerConfig } from "../../updateTestdirectorySchemaFile.js"
 import { DisposableSingleApplication } from "../../utilities/DisposableSingleApplication.js"
 import { TerminalApplication } from "../../utilities/TerminalApplication.js"
 import { resolveMiseStateDirectory } from "../neovim/environment/resolveMiseStateDirectory.js"
@@ -34,6 +39,7 @@ export default class TerminalTestApplication implements AsyncDisposable {
   }
 
   public async startNextAndKillCurrent(
+    config: TestServerConfig,
     testDirectory: TestDirectory,
     startArgs: StartTerminalGenericArguments,
     terminalDimensions: TerminalDimensions,
@@ -55,6 +61,7 @@ export default class TerminalTestApplication implements AsyncDisposable {
 
     await this.application.startNextAndKillCurrent(async () => {
       const env = this.getEnvironmentVariables(
+        config,
         testDirectory,
         xdgRuntimeDirectory.path,
         startArgs.additionalEnvironmentVariables,
@@ -88,22 +95,30 @@ export default class TerminalTestApplication implements AsyncDisposable {
   }
 
   public getEnvironmentVariables(
+    config: TestServerConfig,
     testDirectory: TestDirectory,
     xdgRuntimeDir: string,
     additionalEnvironmentVariables?: Record<string, string>,
   ): Record<string, string> {
     const miseStateDirectory = resolveMiseStateDirectory()
-    return {
+    const env = {
       ...process.env,
       HOME: testDirectory.rootPathAbsolute,
       XDG_CONFIG_HOME: join(testDirectory.rootPathAbsolute, ".config"),
       XDG_DATA_HOME: join(testDirectory.testEnvironmentPath, ".repro", "data"),
       XDG_RUNTIME_DIR: xdgRuntimeDir,
       TUI_SANDBOX_TEST_ENVIRONMENT_PATH: testDirectory.testEnvironmentPath,
-      ...(miseStateDirectory ? { MISE_STATE_DIR: miseStateDirectory } : {}),
-      MISE_OFFLINE: "1",
-      ...additionalEnvironmentVariables,
-    } satisfies TestEnvironmentCommonEnvironmentVariables
+    }
+
+    if (config.integrations.mise) {
+      Object.assign(env, {
+        ...(miseStateDirectory ? { MISE_STATE_DIR: miseStateDirectory } : {}),
+        MISE_OFFLINE: "1",
+      } satisfies MiseIntegrationEnvironmentVariables)
+    }
+
+    Object.assign(env, additionalEnvironmentVariables ?? {})
+    return env satisfies TestEnvironmentCommonEnvironmentVariables
   }
 
   async [Symbol.asyncDispose](): Promise<void> {

--- a/packages/library/src/server/applications/terminal/api.ts
+++ b/packages/library/src/server/applications/terminal/api.ts
@@ -25,6 +25,7 @@ export async function start(
   assert(app, `Terminal with tabId ${tabId.tabId} not found.`)
   const testDirectory = await prepareNewTestDirectory(config)
   await app.startNextAndKillCurrent(
+    config,
     testDirectory,
     {
       commandToRun: startTerminalArguments.commandToRun,
@@ -70,6 +71,7 @@ export async function sendStdin(options: { tabId: TabId; data: string }): Promis
 }
 
 export async function runBlockingShellCommand(
+  config: TestServerConfig,
   signal: AbortSignal | undefined,
   input: BlockingCommandInput,
   allowFailure: boolean,
@@ -91,6 +93,6 @@ export async function runBlockingShellCommand(
     `XDG runtime directory not found for client id ${input.tabId.tabId}. Maybe it's not started yet?`,
   )
 
-  const env = app.getEnvironmentVariables(testDirectory, xdgRuntimeDirectory.path, input.envOverrides)
+  const env = app.getEnvironmentVariables(config, testDirectory, xdgRuntimeDirectory.path, input.envOverrides)
   return executeBlockingShellCommand(testDirectory, input, signal, allowFailure, env)
 }

--- a/packages/library/src/server/applications/terminal/terminalRouter.ts
+++ b/packages/library/src/server/applications/terminal/terminalRouter.ts
@@ -40,7 +40,12 @@ export function createTerminalRouter(config: TestServerConfig) {
     }),
 
     runBlockingShellCommand: trpc.procedure.input(blockingCommandInputSchema).mutation(async options => {
-      return terminal.runBlockingShellCommand(options.signal, options.input, options.input.allowFailure ?? false)
+      return terminal.runBlockingShellCommand(
+        config,
+        options.signal,
+        options.input,
+        options.input.allowFailure ?? false,
+      )
     }),
   })
 

--- a/packages/library/src/server/types.ts
+++ b/packages/library/src/server/types.ts
@@ -75,7 +75,8 @@ export type TestEnvironmentCommonEnvironmentVariables = {
    * @example /Users/mikavilpas/git/tui-sandbox/packages/integration-tests/test-environment
    * */
   TUI_SANDBOX_TEST_ENVIRONMENT_PATH: string
-
+}
+export type MiseIntegrationEnvironmentVariables = {
   /** Points mise at the real user's state directory so it reuses their existing
    * trust database instead of prompting to trust config files (which no test can
    * answer). Trusted configs pass silently; untrusted ones still prompt, keeping

--- a/packages/library/src/server/updateTestdirectorySchemaFile.ts
+++ b/packages/library/src/server/updateTestdirectorySchemaFile.ts
@@ -22,6 +22,7 @@ const neovimIntegration = z.strictObject({
     .min(1)
     .default(["nvim" satisfies NeovimIntegrationDefaultAppName]),
 })
+const miseIntegration = z.strictObject({})
 
 export type FormatterConfig = z.output<typeof formatterConfigSchema>
 const formatterConfigSchema = z
@@ -41,6 +42,7 @@ export const testServerConfigSchema = z.strictObject({
   port: z.number().int().min(1).max(65535).optional().default(3000),
   integrations: z.strictObject({
     neovim: neovimIntegration,
+    mise: miseIntegration.optional(),
   }),
   formatter: formatterConfigSchema,
 })


### PR DESCRIPTION
# feat!: mise integration related features are now opt-in

BREAKING CHANGE: The mise integration is now opt-in. If you want to use it, you need to add the following to your configuration file:

```ts
// /Users/mikavilpas/git/tui-sandbox/packages/integration-tests/tui-sandbox.config.ts
import { createDefaultConfig } from "@tui-sandbox/library/dist/src/server/config.js";
import type { TestServerConfig } from "@tui-sandbox/library/dist/src/server/index.js";

export const config: TestServerConfig = createDefaultConfig(
  process.cwd(),
  process.env,
);
config.integrations.mise = {}; // 👈🏻 add this
```

**Issue:**

More and more mise features are being added to the codebase. I'm worried that they will conflict with something that should not be enabled by default.

**Solution:**

Make everything related to mise integration opt-in. Currently there are no settings to give, so simply specifying `config.integrations.mise = {}` is enough to enable the integration.

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/tui-sandbox/pull/1379 👈🏻