### PR TITLE
fix(mise): prepend mise bin paths to PATH in isolated test env

### DIFF
--- a/packages/library/src/server/applications/neovim/NeovimApplication.ts
+++ b/packages/library/src/server/applications/neovim/NeovimApplication.ts
@@ -17,6 +17,7 @@ import type { TestServerConfig } from "../../updateTestdirectorySchemaFile.js"
 import { DisposableSingleApplication } from "../../utilities/DisposableSingleApplication.js"
 import type { Lazy } from "../../utilities/Lazy.js"
 import { TerminalApplication } from "../../utilities/TerminalApplication.js"
+import { prependMiseBinPathsToPath, resolveMiseBinPaths } from "./environment/resolveMiseBinPaths.js"
 import { resolveMiseStateDirectory } from "./environment/resolveMiseStateDirectory.js"
 import { XdgRuntimeDirectory } from "./environment/XdgRuntimeDirectory.js"
 import { connectNeovimApi } from "./NeovimJavascriptApiClient.js"
@@ -106,6 +107,7 @@ type ResettableState = {
 
 export class NeovimApplication implements AsyncDisposable {
   public state: ResettableState | undefined
+
   public readonly events: EventEmitter
 
   public constructor(
@@ -220,7 +222,7 @@ export class NeovimApplication implements AsyncDisposable {
     NVIM_APPNAME: string | undefined,
     additionalEnvironmentVariables?: Record<string, string>,
   ): Record<string, string> {
-    const env = {
+    let env: Record<string, string> = {
       ...process.env,
       ...({
         HOME: testDirectory.rootPathAbsolute,
@@ -238,6 +240,10 @@ export class NeovimApplication implements AsyncDisposable {
         ...(miseStateDirectory ? { MISE_STATE_DIR: miseStateDirectory } : {}),
         MISE_OFFLINE: "1",
       } satisfies MiseIntegrationEnvironmentVariables)
+
+      // put mise-managed tools' real install dirs on PATH so they are
+      // invocable in the isolated env (shims can't re-resolve there)
+      env = prependMiseBinPathsToPath(env, resolveMiseBinPaths())
     }
 
     Object.assign(env, additionalEnvironmentVariables ?? {})

--- a/packages/library/src/server/applications/neovim/environment/resolveMiseBinPaths.test.ts
+++ b/packages/library/src/server/applications/neovim/environment/resolveMiseBinPaths.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, expect, it } from "vitest"
+
+import {
+  clearMiseBinPathsCache,
+  parseMiseBinPaths,
+  prependMiseBinPathsToPath,
+  resolveMiseBinPaths,
+} from "./resolveMiseBinPaths.js"
+
+afterEach(() => {
+  clearMiseBinPathsCache()
+})
+
+it("parses newline-separated bin paths and ignores blank lines", () => {
+  expect(parseMiseBinPaths("/a/bin\n/b/bin\n\n  /c/bin  \n")).toEqual(["/a/bin", "/b/bin", "/c/bin"])
+})
+
+it("resolves the parsed output of `mise bin-paths`", () => {
+  const binPaths = resolveMiseBinPaths("/repo", {}, () => "/a/bin\n/b/bin\n")
+  expect(binPaths).toEqual(["/a/bin", "/b/bin"])
+})
+
+it("memoizes per working directory (only shells out once)", () => {
+  let calls = 0
+  const run = (): string => {
+    calls++
+    return "/a/bin\n"
+  }
+  resolveMiseBinPaths("/repo", {}, run)
+  resolveMiseBinPaths("/repo", {}, run)
+  expect(calls).toBe(1)
+})
+
+it("crashes when mise is not installed", () => {
+  // The mise integration is opt-in, so a failure here means the user asked for
+  // mise but it could not be used. resolveMiseBinPaths must crash rather than
+  // silently continue, so the misconfiguration is not hidden.
+  expect(() =>
+    resolveMiseBinPaths("/repo", {}, () => {
+      throw Object.assign(new Error("spawn mise ENOENT"), { code: "ENOENT" })
+    }),
+  ).toThrow(/ENOENT/)
+})
+
+it("crashes when `mise bin-paths` exits non-zero", () => {
+  expect(() =>
+    resolveMiseBinPaths("/repo", {}, () => {
+      throw new Error("Command failed")
+    }),
+  ).toThrow(/Command failed/)
+})
+
+it("prepends bin paths so mise-managed tools win over system copies", () => {
+  const env = prependMiseBinPathsToPath({ PATH: "/usr/bin:/bin" }, ["/mise/lazygit/bin", "/mise/delta/bin"])
+  expect(env["PATH"]).toBe("/mise/lazygit/bin:/mise/delta/bin:/usr/bin:/bin")
+})
+
+it("leaves the env untouched when there are no bin paths", () => {
+  const original = { PATH: "/usr/bin", HOME: "/home/user" }
+  expect(prependMiseBinPathsToPath(original, [])).toEqual(original)
+})
+
+it("handles a missing PATH", () => {
+  expect(prependMiseBinPathsToPath({ HOME: "/home/user" }, ["/mise/lazygit/bin"])).toEqual({
+    HOME: "/home/user",
+    PATH: "/mise/lazygit/bin",
+  })
+})

--- a/packages/library/src/server/applications/neovim/environment/resolveMiseBinPaths.ts
+++ b/packages/library/src/server/applications/neovim/environment/resolveMiseBinPaths.ts
@@ -1,0 +1,76 @@
+import { execFileSync } from "child_process"
+import path from "path"
+import { debuglog } from "util"
+
+const log = debuglog("tui-sandbox.mise")
+
+/**
+ * Resolves the bin directories of the currently active, installed mise tools.
+ *
+ * IMPORTANT: resolve this from the *real* server environment, never from the
+ * isolated terminal env.
+ *
+ * NOTE: the selection of tools is assumed stable for the lifetime of the
+ * server process - if you change the mise toolset, you must restart the server
+ * to pick up new bin paths.
+ *
+ * Issue:
+ *
+ * The test terminal runs in a lightly-isolated environment, where a mise
+ * *shim* cannot reliably re-resolve a tool -> version -> backend, so invoking
+ * e.g. `lazygit` through its shim fails with "lazygit is not a valid shim" /
+ * "No version is set for shim".
+ *
+ * Solution:
+ *
+ * Put the tools' real install dirs directly on `$PATH` so they become plain
+ * executables, working around the issue.
+ */
+export type RunMiseBinPaths = (cwd: string, environment: NodeJS.ProcessEnv) => string
+
+const runMiseBinPaths: RunMiseBinPaths = (cwd, environment) =>
+  execFileSync("mise", ["bin-paths"], {
+    cwd,
+    env: environment,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+
+/** Parses the newline-separated output of `mise bin-paths`. */
+export const parseMiseBinPaths = (stdout: string): string[] =>
+  stdout
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+
+// `mise bin-paths` is stable for the lifetime of the server process. Memoize
+// per working directory to avoid shelling out when starting every test.
+const cache = new Map<string, string[]>()
+
+export const resolveMiseBinPaths = (
+  cwd: string = process.cwd(),
+  environment: NodeJS.ProcessEnv = process.env,
+  run: RunMiseBinPaths = runMiseBinPaths,
+): string[] => {
+  const cached = cache.get(cwd)
+  if (cached) return cached
+
+  const binPaths: string[] = parseMiseBinPaths(run(cwd, environment))
+  log(`Resolved ${binPaths.length} mise bin path(s) from ${cwd}`)
+  cache.set(cwd, binPaths)
+  return binPaths
+}
+
+/** @private Test-only: forget memoized results so each test resolves fresh. */
+export const clearMiseBinPathsCache = (): void => {
+  cache.clear()
+}
+
+export const prependMiseBinPathsToPath = (env: Record<string, string>, binPaths: string[]): Record<string, string> => {
+  if (binPaths.length === 0) return env
+  const existing = env["PATH"] ?? ""
+  return {
+    ...env,
+    PATH: [...binPaths, ...(existing ? [existing] : [])].join(path.delimiter),
+  }
+}

--- a/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
+++ b/packages/library/src/server/applications/terminal/TerminalTestApplication.ts
@@ -12,6 +12,7 @@ import type {
 import type { TestServerConfig } from "../../updateTestdirectorySchemaFile.js"
 import { DisposableSingleApplication } from "../../utilities/DisposableSingleApplication.js"
 import { TerminalApplication } from "../../utilities/TerminalApplication.js"
+import { prependMiseBinPathsToPath, resolveMiseBinPaths } from "../neovim/environment/resolveMiseBinPaths.js"
 import { resolveMiseStateDirectory } from "../neovim/environment/resolveMiseStateDirectory.js"
 import { XdgRuntimeDirectory } from "../neovim/environment/XdgRuntimeDirectory.js"
 import type { StdoutOrStderrMessage, TerminalDimensions } from "../neovim/NeovimApplication.js"
@@ -32,6 +33,7 @@ export type StartTerminalGenericArguments = {
 
 export default class TerminalTestApplication implements AsyncDisposable {
   public state: ResettableState | undefined
+
   public readonly events: EventEmitter
 
   public constructor(public readonly application: DisposableSingleApplication = new DisposableSingleApplication()) {
@@ -101,24 +103,28 @@ export default class TerminalTestApplication implements AsyncDisposable {
     additionalEnvironmentVariables?: Record<string, string>,
   ): Record<string, string> {
     const miseStateDirectory = resolveMiseStateDirectory()
-    const env = {
+    let env: Record<string, string> = {
       ...process.env,
       HOME: testDirectory.rootPathAbsolute,
       XDG_CONFIG_HOME: join(testDirectory.rootPathAbsolute, ".config"),
       XDG_DATA_HOME: join(testDirectory.testEnvironmentPath, ".repro", "data"),
       XDG_RUNTIME_DIR: xdgRuntimeDir,
       TUI_SANDBOX_TEST_ENVIRONMENT_PATH: testDirectory.testEnvironmentPath,
-    }
+    } satisfies TestEnvironmentCommonEnvironmentVariables
 
     if (config.integrations.mise) {
       Object.assign(env, {
         ...(miseStateDirectory ? { MISE_STATE_DIR: miseStateDirectory } : {}),
         MISE_OFFLINE: "1",
       } satisfies MiseIntegrationEnvironmentVariables)
+
+      // put mise-managed tools' real install dirs on PATH so they are
+      // invocable in the isolated env (shims can't re-resolve there)
+      env = prependMiseBinPathsToPath(env, resolveMiseBinPaths())
     }
 
     Object.assign(env, additionalEnvironmentVariables ?? {})
-    return env satisfies TestEnvironmentCommonEnvironmentVariables
+    return env
   }
 
   async [Symbol.asyncDispose](): Promise<void> {


### PR DESCRIPTION
# fix(mise): prepend mise bin paths to PATH in isolated test env

**Issue:**

When running tests in an isolated environment, mise-managed tools cannot be invoked through their shims because mise sees the original config file (on the main/host system) is not used anymore, and gets confused.

This is now the default behavior when using https://github.com/jdx/mise-action/releases/tag/v4.2.1 and later, and makes all tools unusable.

**Solution:**

Prepend all the bin directories of the currently active mise-managed tools to the PATH in the isolated test environment, so they can be invoked directly as dumb executables.

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/tui-sandbox/pull/1381 👈🏻