### PR TITLE
ci(perf): don't needlessly install the cypress binaries to save time

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@ name: Linting
 permissions:
   contents: read
 on: [push, pull_request]
+env:
+  CYPRESS_INSTALL_BINARY: "0" # https://docs.cypress.io/app/references/advanced-installation#Environment-variables
 
 jobs:
   markdownlint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+env:
+  CYPRESS_INSTALL_BINARY: "0" # https://docs.cypress.io/app/references/advanced-installation#Environment-variables
 
 permissions:
   contents: read

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -3,6 +3,8 @@
 name: Style checking
 
 on: [push, pull_request]
+env:
+  CYPRESS_INSTALL_BINARY: "0" # https://docs.cypress.io/app/references/advanced-installation#Environment-variables
 
 permissions:
   contents: read


### PR DESCRIPTION
# ci(perf): don't needlessly install the cypress binaries to save time

https://docs.cypress.io/app/references/advanced-installation#Environment-variables

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/tui-sandbox/pull/1394 👈🏻