### PR TITLE
chore(knip): remove redundant configuration

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -9,8 +9,6 @@ const config: KnipConfig = {
   ],
 
   ignoreDependencies: [
-    // Used in CI for link checking, not referenced in code
-    "@umbrelladocs/linkspector",
     // Root devDependency used by integration-tests (which is ignored by knip)
     "cypress",
     // Used for running TypeScript scripts via CLI
@@ -18,14 +16,6 @@ const config: KnipConfig = {
     // Root devDependency satisfying @tui-sandbox/library's peer dependency
     "wait-on",
   ],
-
-  workspaces: {
-    "packages/library": {
-      // package.json exports point to dist/ paths, so knip can't resolve
-      // them to source files automatically
-      entry: ["src/client/index.ts", "src/server/index.ts"],
-    },
-  },
 
   // Don't flag exports that are used within the same file
   ignoreExportsUsedInFile: true,


### PR DESCRIPTION
# chore(knip): remove redundant configuration

```sh
$ knip
Configuration hints (3)
@umbrelladocs/linkspector                    knip.config.ts  Remove from ignoreDependencies
src/client/index.ts        packages/library  knip.config.ts  Remove redundant entry pattern
src/server/index.ts        packages/library  knip.config.ts  Remove redundant entry pattern
✂️  Excellent, Knip found no issues.
```

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/tui-sandbox/pull/1396 👈🏻