### PR TITLE
ci: fix changesets action usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,10 @@ jobs:
         id: changesets
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          version: pnpm changeset version
-          publish: pnpm changeset publish
-          commit: "chore: version packages"
-          title: "chore: version packages"
+          version-script: pnpm changeset version
+          publish-script: pnpm changeset publish
+          commit-message: "chore: version packages"
+          pr-title: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
# ci: fix changesets action usage

https://github.com/mikavilpas/tui-sandbox/actions/runs/33419045668/job/99576631777

```sh
Error: Error: The following inputs have been renamed:
- "publish" -> "publish-script"
- "version" -> "version-script"
- "commit" -> "commit-message"
- "title" -> "pr-title"
Please update your workflow file.
Error: The following inputs have been renamed:
- "publish" -> "publish-script"
- "version" -> "version-script"
- "commit" -> "commit-message"
- "title" -> "pr-title"
Please update your workflow file.
```

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/tui-sandbox/pull/1480 👈🏻