### PR TITLE
ci: pass github-token to changesets action as input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,7 @@ jobs:
           publish-script: pnpm changeset publish
           commit-message: "chore: version packages"
           pr-title: "chore: version packages"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Enable auto-merge on the Version PR
         if: steps.changesets.outputs.pullRequestNumber


### PR DESCRIPTION
# ci: pass github-token to changesets action as input

This seems to have been a breaking change in https://github.com/changesets/action/releases/tag/v2.0.0

https://github.com/mikavilpas/tui-sandbox/actions/runs/33419509638/job/99578149198

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/tui-sandbox/pull/1481 👈🏻